### PR TITLE
Feature/OP-481- Edit Agency Description Box

### DIFF
--- a/public_records_portal/models.py
+++ b/public_records_portal/models.py
@@ -307,6 +307,8 @@ class Request(db.Model):
     #Adding new privacy option for description field
     descriptionPrivate=db.Column(db.Boolean, default=True)
     titlePrivate=db.Column(db.Boolean, default=False)
+    agencyDescription=db.Column(db.String(5000))
+
     def __init__(
             self,
             id,
@@ -317,7 +319,9 @@ class Request(db.Model):
             date_received=None,
             agency=None,
             descriptionPrivate=True,
-            titlePrivate=False
+            titlePrivate=False,
+            agencyDescription=None
+
     ):
         self.id = id
         self.summary = summary
@@ -330,6 +334,7 @@ class Request(db.Model):
         self.department_id = agency
         self.descriptionPrivate = descriptionPrivate
         self.titlePrivacy=titlePrivate
+        self.agencyDescription=agencyDescription
 
 
     def __repr__(self):

--- a/public_records_portal/models.py
+++ b/public_records_portal/models.py
@@ -28,6 +28,11 @@ class notePrivacy:
     PUBLIC = 0x01
     AGENCY = 0x02
 
+class RecordPrivacy:
+    PRIVATE = 0x1
+    RELEASED_AND_PRIVATE = 0x2
+    RELEASED_AND_PUBLIC = 0x3
+
 
 # @export "User"
 class AnonUser:
@@ -668,7 +673,7 @@ class Record(db.Model):
         db.String())  # Where it can be downloaded on the internet.
     access = db.Column(
         db.String())  # How to access it. Probably only defined on offline docs for now.
-    privacy=db.Column(db.Boolean, default=True)
+    privacy=db.Column(db.Integer)
 
     def __init__(
             self,
@@ -679,7 +684,7 @@ class Record(db.Model):
             doc_id=None,
             description=None,
             access=None,
-            privacy=True
+            privacy=RecordPrivacy.PRIVATE
     ):
         self.doc_id = doc_id
         self.request_id = request_id

--- a/public_records_portal/models.py
+++ b/public_records_portal/models.py
@@ -121,7 +121,7 @@ class User(db.Model):
         if self.phone and self.phone != '':
             return self.phone
         return 'N/A'
-    
+
     def get_fax(self):
         if self.fax and self.fax != '':
             return self.fax
@@ -351,7 +351,7 @@ class Request(db.Model):
         if not self.date_received:
             self.date_received = self.date_created
         if self.extended == True:
-            self.due_date = cal.addbusdays(self.date_received, int(app.config['DAYS_AFTER_EXTENSION']))                
+            self.due_date = cal.addbusdays(self.date_received, int(app.config['DAYS_AFTER_EXTENSION']))
         else:
             self.due_date = cal.addbusdays(self.date_received, int(app.config['DAYS_TO_FULFILL']))
 
@@ -417,7 +417,7 @@ class Request(db.Model):
         if requester and requester.user:
             return requester.user.get_phone()
         return 'N/A'
-    
+
     def requester_fax(self):
         requester = self.requester()
         if requester and requester.user:

--- a/public_records_portal/models.py
+++ b/public_records_portal/models.py
@@ -310,10 +310,10 @@ class Request(db.Model):
     offline_submission_type = db.Column(db.String())
     prev_status = db.Column(db.String(400))  # The previous status of the request (open, closed, etc.)
     #Adding new privacy option for description field
-    descriptionPrivate=db.Column(db.Boolean, default=True)
-    titlePrivate=db.Column(db.Boolean, default=False)
-    agencyDescription=db.Column(db.String(5000))
-    agencyDescription_due_date=db.Column(db.DateTime, default=None, nullable=True)
+    description_private=db.Column(db.Boolean, default=True)
+    title_private=db.Column(db.Boolean, default=False)
+    agency_description=db.Column(db.String(5000))
+    agency_description_due_date=db.Column(db.DateTime, default=None, nullable=True)
 
     def __init__(
             self,
@@ -324,10 +324,10 @@ class Request(db.Model):
             offline_submission_type=None,
             date_received=None,
             agency=None,
-            descriptionPrivate=True,
-            titlePrivate=False,
-            agencyDescription=None,
-            agencyDescription_due_date=None
+            description_private=True,
+            title_private=False,
+            agency_description=None,
+            agency_description_due_date=None
     ):
         self.id = id
         self.summary = summary
@@ -338,10 +338,10 @@ class Request(db.Model):
         if date_received and str(type(date_received)) == "<type 'datetime.date'>":
             self.date_received = date_received
         self.department_id = agency
-        self.descriptionPrivate = descriptionPrivate
-        self.titlePrivacy=titlePrivate
-        self.agencyDescription=agencyDescription
-        self.agencyDescription_due_date=agencyDescription_due_date
+        self.description_private = description_private
+        self.titlePrivacy=title_private
+        self.agency_description=agency_description
+        self.agency_description_due_date=agency_description_due_date
 
 
     def __repr__(self):

--- a/public_records_portal/models.py
+++ b/public_records_portal/models.py
@@ -308,6 +308,7 @@ class Request(db.Model):
     descriptionPrivate=db.Column(db.Boolean, default=True)
     titlePrivate=db.Column(db.Boolean, default=False)
     agencyDescription=db.Column(db.String(5000))
+    agencyDescription_due_date=db.Column(db.DateTime, default=None, nullable=True)
 
     def __init__(
             self,
@@ -320,8 +321,8 @@ class Request(db.Model):
             agency=None,
             descriptionPrivate=True,
             titlePrivate=False,
-            agencyDescription=None
-
+            agencyDescription=None,
+            agencyDescription_due_date=None
     ):
         self.id = id
         self.summary = summary
@@ -335,6 +336,7 @@ class Request(db.Model):
         self.descriptionPrivate = descriptionPrivate
         self.titlePrivacy=titlePrivate
         self.agencyDescription=agencyDescription
+        self.agencyDescription_due_date=agencyDescription_due_date
 
 
     def __repr__(self):

--- a/public_records_portal/prr.py
+++ b/public_records_portal/prr.py
@@ -1276,13 +1276,17 @@ def close_request(
                             notification_type=notification_type,
                             notification_content=notification_content)
     add_staff_participant(request_id=request_id, user_id=user_id)
+
+    #Update the time of when the agency description should be released to the public to be 10 days from now
+    updated_due_date = datetime.now() + timedelta(days=10)
+    update_obj(attribute='agencyDescription_due_date', val=updated_due_date,obj_type='Request', obj_id=req.id)
     return None
 
 
 def change_privacy_setting(request_id, privacy, field):
     req = get_obj('Request', request_id)
 
-    if (req.descriptionPrivate==True and privacy==True) or (req.titlePrivate==True and privacy==True):
+    if (req.descriptionPrivate==True and privacy==u'True') or (req.titlePrivate==True and privacy==u'True'):
         if req.agencyDescription == None:
             return "An Agency Description must be created if you are changing the title and description to private"
     if field == 'title':

--- a/public_records_portal/prr.py
+++ b/public_records_portal/prr.py
@@ -1215,6 +1215,13 @@ def close_request(
         request_body=None,
 ):
     req = get_obj('Request', request_id)
+    records = Record.query.filter_by(request_id=request_id).all()
+    for rec in records:
+        if rec.access != None:
+            app.logger.info("Request contains an offline record!")
+            if req.agencyDescription == None:
+                app.logger.info("Agency Description is not filled out")
+                return "You must fill out the Agency Description box before closing this request since you have uploaded an offline document"
     change_request_status(request_id, 'Closed')
     notification_content = {}
     # Create a note to capture closed information:
@@ -1269,6 +1276,7 @@ def close_request(
                             notification_type=notification_type,
                             notification_content=notification_content)
     add_staff_participant(request_id=request_id, user_id=user_id)
+    return None
 
 
 def change_privacy_setting(request_id, privacy, field):

--- a/public_records_portal/prr.py
+++ b/public_records_portal/prr.py
@@ -1300,3 +1300,10 @@ def change_record_privacy(record_id, privacy):
         subprocess.call(["rsync", "-avzh", "--delete", "ssh", app.config['UPLOAD_PUBLIC_LOCAL_FOLDER'] + "/" + record.filename, app.config['PUBLIC_SERVER_USER'] + '@' + app.config['PUBLIC_SERVER_HOSTNAME'] + ':' + app.config['UPLOAD_PUBLIC_REMOTE_FOLDER'] + "/"])
 
     update_obj(attribute="privacy", val=privacy, obj_type="Record", obj_id=record.id)
+
+def edit_agency_description(request_id, agency_description_text):
+    app.logger.info("Modifying agency description of the request")
+    update_obj(attribute='agencyDescription', val=agency_description_text, obj_type='Request', obj_id=request_id)
+
+
+

--- a/public_records_portal/prr.py
+++ b/public_records_portal/prr.py
@@ -1287,7 +1287,7 @@ def change_privacy_setting(request_id, privacy, field):
     req = get_obj('Request', request_id)
 
     if (req.descriptionPrivate==True and privacy==u'True') or (req.titlePrivate==True and privacy==u'True'):
-        if req.agencyDescription == None:
+        if req.agencyDescription == None or req.agencyDescription == u'':
             return "An Agency Description must be created if you are changing the title and description to private"
     if field == 'title':
         # Set the title to private
@@ -1318,6 +1318,9 @@ def change_record_privacy(record_id, privacy):
 
 def edit_agency_description(request_id, agency_description_text):
     app.logger.info("Modifying agency description of the request")
+    req = get_obj('Request',request_id)
+    if (req.descriptionPrivate == True and req.titlePrivate== True):
+        return "An Agency Description must be provided if you are changing the title and description to private."
     update_obj(attribute='agencyDescription', val=agency_description_text, obj_type='Request', obj_id=request_id)
 
 

--- a/public_records_portal/prr.py
+++ b/public_records_portal/prr.py
@@ -1281,8 +1281,11 @@ def close_request(
 
 def change_privacy_setting(request_id, privacy, field):
     req = get_obj('Request', request_id)
-    if field == 'title':
 
+    if (req.descriptionPrivate==True and privacy==True) or (req.titlePrivate==True and privacy==True):
+        if req.agencyDescription == None:
+            return "An Agency Description must be created if you are changing the title and description to private"
+    if field == 'title':
         # Set the title to private
         update_obj(attribute='titlePrivate', val=privacy,
                    obj_type='Request', obj_id=req.id)

--- a/public_records_portal/prr.py
+++ b/public_records_portal/prr.py
@@ -1323,7 +1323,7 @@ def change_record_privacy(record_id, privacy):
     update_obj(attribute="privacy", val=privacy, obj_type="Record", obj_id=record.id)
 
 def edit_agency_description(request_id, agency_description_text):
-    #edit the agency description field of the record
+    #edit the agency description field of the request
     app.logger.info("Modifying agency description of the request")
     update_obj(attribute='agencyDescription', val=agency_description_text, obj_type='Request', obj_id=request_id)
 

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -78,12 +78,39 @@
   });
 
   $('#submit').on('click',function(event){
+    console.log("SUBMITTING...")
+    alert("submission javascript");
     form_id = '#' + $('#form_id').val();
     if(!$('#modalAdditionalInfoTable').is(':visible') || $(form_id) == 'note_pdf') {
+        alert("abcdefghijklmn");
         $('#confirm-submit').modal('toggle');
         $(form_id).submit();
     }
     else {
+        alert("abcdefghijklmn2");
+      $('#modalAdditionalInfoTable').show();
+      $('#editAgencyDescription').hide();
+      additional_information = $('#additional_note').val();
+      var input = $("<input>")
+               .attr("type", "hidden")
+               .attr("name", "additional_information").val(additional_information);
+      $(form_id).append($(input));
+      $(form_id).submit();
+    }
+
+   });
+
+  $('#submitAgencyDescription').on('click',function(event){
+    console.log("SUBMITTING...")
+    alert("submission javascript");
+    form_id = '#' + $('#form_id').val();
+    if(!$('#modalAdditionalInfoTable').is(':visible') || $(form_id) == 'note_pdf') {
+        alert("abcdefghijklmn");
+        $('#confirm-submit').modal('toggle');
+        $(form_id).submit();
+    }
+    else {
+        alert("abcdefghijklmn2");
       $('#modalAdditionalInfoTable').show();
       $('#editAgencyDescription').hide();
       additional_information = $('#additional_note').val();

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -93,7 +93,7 @@
                .attr("name", "additional_information").val(additional_information);
       $(form_id).append($(input));
         console.log(form_id);
-      $(form_id).submit();
+      //$(form_id).submit();
         console.log("subbmitting");
     }
    });
@@ -161,7 +161,7 @@ $('#editAgencyDescriptionButton').on('click',function(){
     $('#modalAdditionalInfoTable').show();
     var modalQuestion = 'Type in the agency description below';
     modalQuestion += '<br><br>';
-    $('#form_id').val('agencyDescription');
+    $('#form_id').val('agencyDescription') ;
     console.log("hello");
     console.log($('#form_id').val('agencyDescription'));
     $('#modalquestionDiv').html(modalQuestion);

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -78,16 +78,12 @@
   });
 
   $('#submit').on('click',function(event){
-    console.log("SUBMITTING...")
-    alert("submission javascript");
     form_id = '#' + $('#form_id').val();
     if(!$('#modalAdditionalInfoTable').is(':visible') || $(form_id) == 'note_pdf') {
-        alert("abcdefghijklmn");
         $('#confirm-submit').modal('toggle');
         $(form_id).submit();
     }
     else {
-        alert("abcdefghijklmn2");
       $('#modalAdditionalInfoTable').show();
       $('#editAgencyDescription').hide();
       additional_information = $('#additional_note').val();

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -49,10 +49,10 @@
         $('#acknowledgeRequestForm').hide();
       }
   });
- 
+
   $("#days_after").change(function() {
     selected = $(this).val();
-    if(selected === "0") { 
+    if(selected === "0") {
       $("#custom_due_date").show();
       }
     else {
@@ -63,7 +63,7 @@
 
   $("#days_after").change(function() {
     selected = $(this).val();
-    if(selected === "-1") { 
+    if(selected === "-1") {
       $("#custom_due_date").show();
     }
     else {
@@ -97,16 +97,12 @@
    });
 
   $('#submitAgencyDescription').on('click',function(event){
-    console.log("SUBMITTING...")
-    alert("submission javascript");
     form_id = '#' + $('#form_id').val();
     if(!$('#modalAdditionalInfoTable').is(':visible') || $(form_id) == 'note_pdf') {
-        alert("abcdefghijklmn");
         $('#confirm-submit').modal('toggle');
         $(form_id).submit();
     }
     else {
-        alert("abcdefghijklmn2");
       $('#modalAdditionalInfoTable').show();
       $('#editAgencyDescription').hide();
       additional_information = $('#additional_note').val();
@@ -167,7 +163,7 @@
   $('#closeButton').on('click',function(){
     var selectedCloseReason = $('#close_reasons option:selected').text();
     if(selectedCloseReason.indexOf('Denied') >= 0) {
-        $('#deny_explain_why').show();  
+        $('#deny_explain_why').show();
     }
     else {
         $('#deny_explain_why').hide();
@@ -219,10 +215,10 @@ $('#file_upload_filenames').bind('DOMNodeInserted', function(event) {
       $('#file_upload_four').text(names[3]);
       $('#numFiles').hide();
   }
-  
+
 });
 
-$('#close_filenames_list').on('click',function(){ 
+$('#close_filenames_list').on('click',function(){
   $('#file_upload_one').empty();
   $('#file_upload_two').empty();
   $('#file_upload_three').empty();
@@ -256,11 +252,11 @@ $('#close_filenames_list').on('click',function(){
       $('#modalquestionDiv').html(modalQuestion);
       $('#modalQuestionTable').hide();
     });
- 
+
   $('#generatePDFButton').on('click',function(event){
     var selectedTemplate = $('#response_template option:selected').text();
     var modalQuestion = 'Are you sure you want to generate a Word Document for the template below?';
-           
+
     if (selectedTemplate === '') {
       $('#missing_pdf_template').removeClass('hidden');
     }
@@ -269,22 +265,22 @@ $('#close_filenames_list').on('click',function(){
             $('#deny_explain_why').show();
         }
         else {
-            $('#deny_explain_why').hide(); 
+            $('#deny_explain_why').hide();
         }
         $('#missing_pdf_template').addClass('hidden');
         var attr = $('#generatePDFButton').attr('data-toggle');
         $('#generatePDFButton').attr('data-toggle','modal');
         $('#generatePDFButton').attr('data-target','#confirm-submit');
-                             
+
         $('#modalAdditionalInfoTable').hide();
         $('#form_id').val('note_pdf');
         modalQuestion += '<br><br>' + selectedTemplate;
         $('#modalquestionDiv').html(modalQuestion);
         $('#modalQuestionTable').hide();
     }
-                            
-        
-        
+
+
+
   });
 
   $('#notifyButton').on('click',function(){

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -97,7 +97,6 @@
    });
 
     $('#cancelDescription').on('click',function(event){
-        alert("Inside cancel description javascript funciton");
         $('#editAgencyDescription').hide();
         $('#additionalInformation').show();
         form_id = '#' + $('#form_id').val();

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -80,18 +80,21 @@
   $('#submit').on('click',function(event){
     form_id = '#' + $('#form_id').val();
     if(!$('#modalAdditionalInfoTable').is(':visible') || $(form_id) == 'note_pdf') {
+        console.log("going to if");
         $('#confirm-submit').modal('toggle');
         $(form_id).submit();
     }
     else {
-
+        console.log("going to else");
       $('#modalAdditionalInfoTable').show();
       additional_information = $('#additional_note').val();
       var input = $("<input>")
                .attr("type", "hidden")
                .attr("name", "additional_information").val(additional_information);
       $(form_id).append($(input));
+        console.log(form_id);
       $(form_id).submit();
+        console.log("subbmitting");
     }
    });
 
@@ -155,7 +158,8 @@
 
 
 $('#editAgencyDescriptionButton').on('click',function(){
-    var modalQuestion = 'Type in the agency description below'
+    $('#modalAdditionalInfoTable').show();
+    var modalQuestion = 'Type in the agency description below';
     modalQuestion += '<br><br>';
     $('#form_id').val('agencyDescription');
     console.log("hello");

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -80,21 +80,17 @@
   $('#submit').on('click',function(event){
     form_id = '#' + $('#form_id').val();
     if(!$('#modalAdditionalInfoTable').is(':visible') || $(form_id) == 'note_pdf') {
-        console.log("going to if");
         $('#confirm-submit').modal('toggle');
         $(form_id).submit();
     }
     else {
-        console.log("going to else");
       $('#modalAdditionalInfoTable').show();
       additional_information = $('#additional_note').val();
       var input = $("<input>")
                .attr("type", "hidden")
                .attr("name", "additional_information").val(additional_information);
       $(form_id).append($(input));
-        console.log(form_id);
       $(form_id).submit();
-        console.log("subbmitting");
     }
    });
 
@@ -162,8 +158,6 @@ $('#editAgencyDescriptionButton').on('click',function(){
     var modalQuestion = 'Type in the agency description below';
     modalQuestion += '<br><br>';
     $('#form_id').val('agencyDescription') ;
-    console.log("hello");
-    console.log($('#form_id').val('agencyDescription'));
     $('#modalquestionDiv').html(modalQuestion);
     $('#modalQuestionTable').hide();
 });

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -154,6 +154,16 @@
   });
 
 
+$('#editAgencyDescriptionButton').on('click',function(){
+    var modalQuestion = 'Type in the agency description below'
+    modalQuestion += '<br><br>';
+    $('#form_id').val('agencyDescription');
+    console.log("hello");
+    console.log($('#form_id').val('agencyDescription'));
+    $('#modalquestionDiv').html(modalQuestion);
+    $('#modalQuestionTable').hide();
+});
+
 $('#file_upload_filenames').bind('DOMNodeInserted', function(event) {
   var names = [];
   if($("input[name=record]") && $("input[name=record]").get(0) && $("input[name=record]").get(0).files) {
@@ -194,6 +204,7 @@ $('#close_filenames_list').on('click',function(){
   $('#addNoteButton').on('click',function(){
     $('#modalAdditionalInfoTable').show();
     $('#form_id').val('note');
+    console.log($('#form_id').val('note'));
     var modalQuestion = 'Are you sure you want to add the note below and send an email to the requester?';
     modalQuestion += '<br><br>' + $('#noteTextarea').val();
     $('#modalquestionDiv').html(modalQuestion);

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -85,6 +85,7 @@
     }
     else {
       $('#modalAdditionalInfoTable').show();
+      $('#editAgencyDescription').hide();
       additional_information = $('#additional_note').val();
       var input = $("<input>")
                .attr("type", "hidden")
@@ -92,7 +93,21 @@
       $(form_id).append($(input));
       $(form_id).submit();
     }
+
    });
+
+    $('#cancelDescription').on('click',function(event){
+        alert("Inside cancel description javascript funciton");
+        $('#editAgencyDescription').hide();
+        $('#additionalInformation').show();
+        form_id = '#' + $('#form_id').val();
+        additional_information = "";
+        var input = $("<input>")
+            .attr("type", "hidden")
+            .attr("name", "additional_information").val(additional_information);
+        $(form_id).append($(input));
+        $(form_id).submit();
+    });
 
     $('#cancel_close').on('click',function(event){
         $('#close-reminder').hide();
@@ -154,10 +169,12 @@
 
 
 $('#editAgencyDescriptionButton').on('click',function(){
-    $('#modalAdditionalInfoTable').show();
+    //$('#modalAdditionalInfoTable').hide();
+    $('#editAgencyDescription').show();
+    $('#additionalInformation').hide();
     var modalQuestion = 'Type in the agency description below';
     modalQuestion += '<br><br>';
-    $('#form_id').val('agencyDescription') ;
+    $('#form_id').val('agencyDescription');
     $('#modalquestionDiv').html(modalQuestion);
     $('#modalQuestionTable').hide();
 });

--- a/public_records_portal/static/js/case.js
+++ b/public_records_portal/static/js/case.js
@@ -93,7 +93,7 @@
                .attr("name", "additional_information").val(additional_information);
       $(form_id).append($(input));
         console.log(form_id);
-      //$(form_id).submit();
+      $(form_id).submit();
         console.log("subbmitting");
     }
    });

--- a/public_records_portal/static/js/manage_request_city.js
+++ b/public_records_portal/static/js/manage_request_city.js
@@ -250,5 +250,5 @@ $(document).ready(function() {
     $parent.append("<div class='more'>..more</div>");
   })
 
-})
+})}
 

--- a/public_records_portal/templates/_response_actions.html
+++ b/public_records_portal/templates/_response_actions.html
@@ -250,7 +250,11 @@
 <div class="row-fluid">
     <div class="span12">
         <ul class="nav nav-pills" role="tablist">
-            {% if form %}
+            {% if form=='close' %}
+            <li><a href="#add_record" role="tab" data-toggle="tab">
+                <small>Add Record</small>
+            </a></li>
+            {% elif form and form !='close'%}
             <li class="active"><a href="#add_record" role="tab" data-toggle="tab">
                 <small>Add Record</small>
             </a></li>
@@ -259,7 +263,6 @@
                 <small>Add Record</small>
             </a></li>
             {% endif %}
-
             <li><a href="#add_note" role="tab" data-toggle="tab">
                 <small>Add Note</small>
             </a></li>
@@ -269,9 +272,15 @@
             <li><a href="#generate_pdf" role="tab" data-toggle="tab">
                 <small>Generate Letter</small>
             </a></li>
+            {% if form=='close' %}
+            <li class="active"><a href="#close_request" role="tab" data-toggle="tab">
+                <small>Close Request</small>
+            </a></li>
+            {% else %}
             <li><a href="#close_request" role="tab" data-toggle="tab">
                 <small>Close Request</small>
             </a></li>
+            {% endif %}
             <li><a href="#manage_helpers" role="tab" data-toggle="tab">
                 <small>Manage Helpers</small>
             </a></li>
@@ -283,7 +292,7 @@
 </div>
 <div class="row-fluid" style="width:98%;">
     <div class="tab-content">
-    {% if form %}
+    {% if form and form != 'close' %}
         <div class="active tab-pane" id="add_record">
     {% else %}
         <div class="tab-pane" id="add_record">
@@ -661,7 +670,12 @@
                 </fieldset>
             </form>
         </div>
-        <div class="tab-pane" id="close_request">
+        {% if form=='close' %}
+            <div class="active tab-pane" id="close_request">
+        {% else %}
+            <div class="tab-pane" id ="close_request">
+        {% endif %}
+{#        <div class="tab-pane" id ="close_request">#}
             <form name="close" id="closeRequest" method="post" action="/close">
                 <input type="hidden" name="request_id" value="{{ req.id }}"/>
                 <input name=_csrf_token type=hidden value="{{ csrf_token() }}">

--- a/public_records_portal/templates/_response_actions.html
+++ b/public_records_portal/templates/_response_actions.html
@@ -687,6 +687,10 @@
                     <div class="alert alert-danger" id="missing_agency_description">
                         {{ errors['missing_agency_description'] }}</div>
                 {% endif %}
+                {% if "missing_agency_description_record_privacy" in errors %}
+                    <div class="alert alert-danger" id="missing_agency_record_privacy">
+                        {{ errors['missing_agency_description_record_privacy'] }}</div>
+                {% endif %}
                 <fieldset>
                     <legend>Close request</legend>
                     <div class="row-fluid" style="width:98%;">

--- a/public_records_portal/templates/_response_actions.html
+++ b/public_records_portal/templates/_response_actions.html
@@ -665,6 +665,10 @@
             <form name="close" id="closeRequest" method="post" action="/close">
                 <input type="hidden" name="request_id" value="{{ req.id }}"/>
                 <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
+                {% if "missing_agency_description" in errors %}
+                    <div class="alert alert-danger" id="missing_agency_description">
+                        {{ errors['missing_agency_description'] }}</div>
+                {% endif %}
                 <fieldset>
                     <legend>Close request</legend>
                     <div class="row-fluid" style="width:98%;">

--- a/public_records_portal/templates/_response_actions.html
+++ b/public_records_portal/templates/_response_actions.html
@@ -1,6 +1,10 @@
 {% if current_user.is_authenticated %}
 {% if req.solid_status() == 'open' %}
 <div class="row-fluid">
+{#    {% if "missing_agency_description_privacy" in errors %}#}
+{#        <div class="alert alert-danger" id="missing_agency_description_privacy">#}
+{#            {{ errors['missing_agency_description_privacy'] }}</div>#}
+{#    {% endif %}#}
     <div class="span12">
         <ul class="nav nav-pills nav-justified" role="tablist">
             <li>

--- a/public_records_portal/templates/_response_actions.html
+++ b/public_records_portal/templates/_response_actions.html
@@ -591,7 +591,6 @@
                                         class="btn btn-default btn-block">Extend
                                     this request
                                 </button>
-
                             </div>
                         </div>
                     </div>

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -78,7 +78,7 @@
                     <div class="alert alert-danger" id="missing_agency_description_privacy">
                         {{ errors['missing_agency_description_privacy'] }}</div>
                 {% endif %}
-                {% if (current_user.is_authenticated and audience == 'city') or req.agencyDescription_due_date < datetime.now()%}
+                {% if (current_user.is_authenticated and audience == 'city') or (req.agencyDescription_due_date and req.agencyDescription_due_date < datetime.now() ) %}
                     {% if req.agencyDescription != None %}
                         {% if req.agencyDescription.decode("utf-8")|length > 50 %}
                             Agency Description: {{ req.agencyDescription[0:50] }}...
@@ -133,7 +133,7 @@
                     </form>
 
                     <div class="modal fade agencyDescriptionModal" id="agencyDescriptionModal" tabindex="-1" role="dialog"
-                         aria-labelledby="myModalLabel" aria-hidden="true" style="height: 40em; width:60em;">
+                         aria-labelledby="myModalLabel" aria-hidden="true" style="width:60em;">
                         <div class="modal-dialog">
                             <div class="modal-content">
                                 <div class="modal-header">
@@ -143,26 +143,18 @@
                                     <div id="modalquestionDiv">Are you sure you want to make the following question
                                         public and send an email to the requester?
                                     </div>
-{#                                    <table id="modalQuestionTable" class="table">#}
-{#                                        <tr>#}
-{#                                            <th>Question</th>#}
-{#                                            <td id="question_text"></td>#}
-{#                                            <input type="hidden" id="form_id" value=""/>#}
-{#                                        </tr>#}
-{#                                    </table>#}
-
                                     <table id="modalAdditionalInfoTable" class="table">
                                         <tr id="editAgencyDescription" style="display:None;">
                                             <th>Agency Description <br>(5000 character limit) <br></th>
-                                            {% if req.agencyDescription != "None" %}
-                                                <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"
-                                                              class="input-xlarge" maxlength="5000"
-                                                              placeholder="Agency Description">{{ req.agencyDescription }}</textarea></td>
+                                            {% if req.agencyDescription and req.agencyDescription != "None" %}
+                                                <td><textarea style="width: 30em; height: 10em;" id="additional_note" name="additional_note"
+                                                              class="input-large" maxlength="5000"
+                                                              placeholder="Agency Description" >{{ req.agencyDescription }}</textarea></td>
                                             {% else %}
-                                                    <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"
-                                                              class="input-xlarge"
+                                                    <td><textarea style="width: 30em; height: 10em;" id="additional_note" name="additional_note"
+                                                              class="input-large"
                                                               placeholder="Agency Description"
-                                                                maxlength="5000"></textarea></td>
+                                                                maxlength="5000" ></textarea></td>
                                             {% endif %}
 
                                         </tr>

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -151,14 +151,15 @@
                                     <table id="modalAdditionalInfoTable" class="table">
                                         <tr id="editAgencyDescription" style="display:None;">
                                             <th>Agency Description <br>(5000 character limit) <br></th>
-                                            {% if req.agencyDescription != None or (req.agencyDescription) != '' %}
-                                                <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note" class="input-xlarge" maxlength="5000">{{ req.agencyDescription }}</textarea></td>
+                                            {% if req.agencyDescription != "None" %}
+                                                <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"
+                                                              class="input-xlarge" maxlength="5000"
+                                                              placeholder="Agency Description">{{ req.agencyDescription }}</textarea></td>
                                             {% else %}
                                                     <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"
                                                               class="input-xlarge"
                                                               placeholder="Agency Description"
-                                                                maxlength="5000">
-                                                    </textarea></td>
+                                                                maxlength="5000"></textarea></td>
                                             {% endif %}
 
                                         </tr>
@@ -208,16 +209,16 @@
 {#                                    </table>#}
 
                                     <table id="modalAdditionalInfoTable" class="table">
-                                        <tr id="editAgencyDescription" style="display:None;">
-                                            <th>Agency Description <br>(5000 character limit) <br></th>
+{#                                        <tr id="editAgencyDescription" style="display:None;">#}
+{#                                            <th>Agency Description <br>(5000 character limit) <br></th>#}
 {#                                            {% if req.agencyDescription != "" %}#}
-                                                <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"
-                                                              class="input-xlarge"
-                                                              placeholder="Agency Description"
-                                                                maxlength="5000">{{ req.agencyDescription }}
-                                                    </textarea></td>
+{#                                                <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"#}
+{#                                                              class="input-xlarge"#}
+{#                                                              placeholder="Agency Description"#}
+{#                                                                maxlength="5000">{{ req.agencyDescription }}#}
+{#                                                    </textarea></td>#}
 {#                                            {% endif %}#}
-                                        </tr>
+{#                                        </tr>#}
                                         <tr id="additionalInformation">
                                             <th>Additional Information</th>
                                             <td><textarea id="additional_note" name="additional_note"

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -71,6 +71,33 @@
                         {% endif %}
                         {% endif %}
                     </h3>
+                <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
+                    {% if req.agencyDescription != None %}
+                        Agency Description: {{ req.agencyDescription }}
+                    {% endif %}
+                </p>
+                {% if current_user.is_authenticated %}
+                    <form name="agency_description" id="agencyDescription" method="post" action="/agencyDescription">
+                        <input type="hidden" name="request_id" value="{{ req.id }}"/>
+                        <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
+                        <fieldset>
+                            <div class="row-fluid" style="width:98%;">
+                                <div class="control-group">
+                                    <div class="controls">
+                                        <button type="submit"
+                                                class="btn btn-default btn-level"
+                                                data-toggle="modal"
+                                                data-target="#confirm-submit"
+                                                id="editAgencyDescriptionButton">Edit Agency Description
+                                        </button>
+                                    </div>
+                                    <input type="hidden" name="agency_description" value="1"/>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </form>
+            {% endif %}
+
                     {% block clarify_request %}
                     <!-- ask a question -->
                     <form name="ask_question" id="question" class="form-inline" style="margin: 10px 0px 15px 0px;"
@@ -291,11 +318,6 @@
 
                         </fieldset>
                         {% endif %}
-                        <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
-                            {% if req.agencyDescription != None %}
-                                Agency Description: {{ req.agencyDescription }}
-                            {% endif %}
-                        </p>
                     </form>
 
                         </div>
@@ -337,27 +359,7 @@
                     <!--{% endif %}-->
                 <!--</div>-->
             </div>
-            {% if current_user.is_authenticated %}
-                <form name="agency_description" id="agencyDescription" method="post" action="/agencyDescription">
-                    <input type="hidden" name="request_id" value="{{ req.id }}"/>
-                    <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
-                    <fieldset>
-                        <div class="row-fluid" style="width:98%;">
-                            <div class="control-group">
-                                <div class="controls">
-                                    <button type="submit"
-                                            class="btn btn-default btn-level"
-                                            data-toggle="modal"
-                                            data-target="#confirm-submit"
-                                            id="editAgencyDescriptionButton">Edit Agency Description
-                                    </button>
-                                </div>
-                                <input type="hidden" name="agency_description" value="1"/>
-                            </div>
-                        </div>
-                    </fieldset>
-                </form>
-            {% endif %}
+
             {% endblock request %}
         </div>
         {% endblock well %}

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -185,7 +185,7 @@
                                     </table>
                                 </div>
                                 <div class="modal-footer">
-                                    <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDescription">Canceled</button>
+                                    <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDescription">Cancel</button>
                                     <a href="#" id="submitAgencyDescription" class="btn btn-success success">Submit</a>
                                 </div>
                             </div>

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -72,11 +72,20 @@
                         {% endif %}
                     </h3>
                 <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
+{#                {{ req.agencyDescription.decode("utf-8") }}#}
+{#                {{ req.agencyDescription.split('') }}#}
                     {% if req.agencyDescription != None %}
-                        Agency Description: {{ req.agencyDescription }}
+{#                        {% if len(bytes.decode(req.agencyDescription)) > 50 %}#}
+{#                        {% if (req.agencyDescription.decode("utf-8")) > 50 %}#}
+                        {% if req.agencyDescription.decode("utf-8")|length > 50 %}
+                            Agency Description: {{ req.agencyDescription[0:50] }}...
+                        {% else %}
+                            Agency Description: {{ req.agencyDescription }}
+                        {% endif %}
+
                     {% endif %}
                 </p>
-                {% if current_user.is_authenticated %}
+                {% if current_user.is_authenticated and audience == 'city' %}
                     <form name="agency_description" id="agencyDescription" method="post" action="/agencyDescription">
                         <input type="hidden" name="request_id" value="{{ req.id }}"/>
                         <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
@@ -87,7 +96,7 @@
                                         <button type="submit"
                                                 class="btn btn-default btn-level"
                                                 data-toggle="modal"
-                                                data-target="#confirm-submit"
+                                                data-target=".agencyDescriptionModal"
                                                 id="editAgencyDescriptionButton">Edit Agency Description
                                         </button>
                                     </div>
@@ -96,7 +105,7 @@
                             </div>
                         </fieldset>
                     </form>
-            {% endif %}
+                {% endif %}
 
                     {% block clarify_request %}
                     <!-- ask a question -->
@@ -120,8 +129,8 @@
                         </fieldset>
                     </form>
 
-                    <div class="modal fade" id="confirm-submit" tabindex="-1" role="dialog"
-                         aria-labelledby="myModalLabel" aria-hidden="true">
+                    <div class="modal fade agencyDescriptionModal" id="confirm-submit2" tabindex="-1" role="dialog"
+                         aria-labelledby="myModalLabel" aria-hidden="true" style="height: 40em; width:40em;">
                         <div class="modal-dialog">
                             <div class="modal-content">
                                 <div class="modal-header">
@@ -138,8 +147,22 @@
                                             <input type="hidden" id="form_id" value=""/>
                                         </tr>
                                     </table>
+
                                     <table id="modalAdditionalInfoTable" class="table">
-                                        <tr>
+                                        <tr id="editAgencyDescription" style="display:None;">
+                                            <th>Agency Description <br>(5000 character limit) <br></th>
+                                            {% if req.agencyDescription != None or (req.agencyDescription) != '' %}
+                                                <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note" class="input-xlarge" maxlength="5000">{{ req.agencyDescription }}</textarea></td>
+                                            {% else %}
+                                                    <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"
+                                                              class="input-xlarge"
+                                                              placeholder="Agency Description"
+                                                                maxlength="5000">
+                                                    </textarea></td>
+                                            {% endif %}
+
+                                        </tr>
+                                        <tr id="additionalInformation">
                                             <th>Additional Information</th>
                                             <td><textarea id="additional_note" name="additional_note"
                                                           class="input-xlarge"
@@ -158,7 +181,63 @@
                                     </table>
                                 </div>
                                 <div class="modal-footer">
-                                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                    <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDescription">Cancel</button>
+                                    <a href="#" id="submit" class="btn btn-success success">Submit</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="modal fade" id="confirm-submit" tabindex="-1" role="dialog"
+                         aria-labelledby="myModalLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    Confirmation
+                                </div>
+                                <div class="modal-body">
+                                    <div id="modalquestionDiv">Are you sure you want to make the following question
+                                        public and send an email to the requester?
+                                    </div>
+{#                                    <table id="modalQuestionTable" class="table">#}
+{#                                        <tr>#}
+{#                                            <th>Question</th>#}
+{#                                            <td id="question_text"></td>#}
+{#                                            <input type="hidden" id="form_id" value=""/>#}
+{#                                        </tr>#}
+{#                                    </table>#}
+
+                                    <table id="modalAdditionalInfoTable" class="table">
+                                        <tr id="editAgencyDescription" style="display:None;">
+                                            <th>Agency Description <br>(5000 character limit) <br></th>
+{#                                            {% if req.agencyDescription != "" %}#}
+                                                <td><textarea style="width: 30em; height: 20em;" id="additional_note" name="additional_note"
+                                                              class="input-xlarge"
+                                                              placeholder="Agency Description"
+                                                                maxlength="5000">{{ req.agencyDescription }}
+                                                    </textarea></td>
+{#                                            {% endif %}#}
+                                        </tr>
+                                        <tr id="additionalInformation">
+                                            <th>Additional Information</th>
+                                            <td><textarea id="additional_note" name="additional_note"
+                                                          class="input-xlarge"
+                                                          placeholder="Additional Information"/></textarea></td>
+                                        </tr>
+                                    </table>
+                                    <br/><br/>
+                                    <table id="modalAdditionalInfoTableClose" class="table" style="display:none;">
+                                        <p id="deny_explain_why" style="display:none;"><b>If you are denying this request please explain why.</b></p>
+                                        <tr>
+                                            <th>Additional Information for Closing</th>
+                                            <td><textarea id="additional_note" name="additional_note"
+                                                          class="input-xlarge"
+                                                          placeholder="Additional Information"/></textarea></td>
+                                        </tr>
+                                    </table>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal" id="cancel">Cancel</button>
                                     <a href="#" id="submit" class="btn btn-success success">Submit</a>
                                 </div>
                             </div>

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -288,7 +288,19 @@
                                     {% endif %}
                                 </div>
                             </div>
-                        <div class="tab-pane" id="agencyDescription">
+                        {% if current_user.is_authenticated %}
+                            <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
+                                {% if req.agencyDescription != None %}
+                                    {{ req.agencyDescription }}
+
+                                {% endif %}
+                            </p>
+                        {% endif %}
+
+                        </fieldset>
+                    </form>
+                    {% endif %}
+                <div class="tab-pane" id="agencyDescription">
                             <form name="agency_Description" id="agencyDescription" method="post" action="/agencyDescription">
                                 <input type="hidden" name="request_id" value="{{ req.id }}"/>
 {#                                <input name=_csrf_token type=hidden value="{{ csrf_token() }}">#}
@@ -320,33 +332,9 @@
                                             </div>
                                             <input type="hidden" name="agency_description" value="1"/>
                                         </div>
-
-                                                <div class="control-group">
-{#                                                    <div class="controls">#}
-{#                                                        <button id="extendButton" data-toggle="modal"#}
-{#                                                                data-target="#confirm-submit"#}
-{#                                                                type="submit"#}
-{#                                                                class="btn btn-default btn-block">Extend#}
-{#                                                            this request#}
-{#                                                        </button>#}
-{#                                                    </div>#}
-{#                                                </div>#}
-                                                </div>
                                 </fieldset>
                             </form>
                         </div>
-                        {% if current_user.is_authenticated %}
-                            <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
-                                {% if req.agencyDescription != None %}
-                                    {{ req.agencyDescription }}
-
-                                {% endif %}
-                            </p>
-                        {% endif %}
-
-                        </fieldset>
-                    </form>
-                    {% endif %}
                 </div>
                 <!--<div>-->
                     <!--&lt;!&ndash; shows any existing Q&A or public notes &ndash;&gt;-->

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -288,6 +288,62 @@
                                     {% endif %}
                                 </div>
                             </div>
+                        <div class="tab-pane" id="agencyDescription">
+                            <form name="agencyDescription" id="agencyDescription" method="post" action="/editAgencyDescription">
+                                <input type="hidden" name="request_id" value="{{ req.id }}"/>
+{#                                <input name=_csrf_token type=hidden value="{{ csrf_token() }}">#}
+                                <fieldset>
+                                    <div class="row-fluid" style="width:98%;">
+{#                                        <div class="control-group">#}
+{#                                            <label class="control-label">Note <span#}
+{#                                                    rel="tooltip" data-toggle="tooltip"#}
+{#                                                    data-placement="right" title=""#}
+{#                                                    data-original-title="{{ 'Add a note' | explain_action }}">#}
+{#                                                <small><i class="icon-info-sign"></i></small>#}
+{#                                                </span></label>#}
+{##}
+{#                                            <div class="controls">#}
+{#                                                <textarea type="text" class="input-xxlarge"#}
+{#                                                          id="noteTextarea" name="note_text"#}
+{#                                                          placeholder="Notes visible to staff only."#}
+{#                                                          required/></textarea>#}
+{#                                            </div>#}
+{#                                        </div>#}
+                                        <div class="control-group">
+                                            <div class="controls">
+                                                <button type="submit"
+                                                        class="btn btn-default btn-block"
+                                                        data-toggle="modal"
+                                                        data-target="#confirm-submit"
+                                                        id="editAgencyDescriptionButton">Edit Agency Description
+                                                </button>
+                                            </div>
+                                            <input type="hidden" name="agency_description" value="1"/>
+                                        </div>
+
+                                                <div class="control-group">
+{#                                                    <div class="controls">#}
+{#                                                        <button id="extendButton" data-toggle="modal"#}
+{#                                                                data-target="#confirm-submit"#}
+{#                                                                type="submit"#}
+{#                                                                class="btn btn-default btn-block">Extend#}
+{#                                                            this request#}
+{#                                                        </button>#}
+{#                                                    </div>#}
+{#                                                </div>#}
+                                                </div>
+                                </fieldset>
+                            </form>
+                        </div>
+                        {% if current_user.is_authenticated %}
+                            <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
+                                {% if req.agencyDescription != None %}
+                                    {{ req.agencyDescription }}
+
+                                {% endif %}
+                            </p>
+                        {% endif %}
+
                         </fieldset>
                     </form>
                     {% endif %}

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -74,6 +74,10 @@
                 <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
 {#                {{ req.agencyDescription.decode("utf-8") }}#}
 {#                {{ req.agencyDescription.split('') }}#}
+                {% if "missing_record_description" in errors %}
+                    <div class="alert alert-danger" id="missing_agency_description">
+                        {{ errors['missing_record_description'] }}</div>
+                {% endif %}
                     {% if req.agencyDescription != None %}
 {#                        {% if len(bytes.decode(req.agencyDescription)) > 50 %}#}
 {#                        {% if (req.agencyDescription.decode("utf-8")) > 50 %}#}

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -300,7 +300,6 @@
                         </fieldset>
                     </form>
                     {% endif %}
-                <div class="tab-pane" id="agencyDescription">
                             <form name="agency_Description" id="agencyDescription" method="post" action="/agencyDescription">
                                 <input type="hidden" name="request_id" value="{{ req.id }}"/>
 {#                                <input name=_csrf_token type=hidden value="{{ csrf_token() }}">#}
@@ -335,7 +334,6 @@
                                 </fieldset>
                             </form>
                         </div>
-                </div>
                 <!--<div>-->
                     <!--&lt;!&ndash; shows any existing Q&A or public notes &ndash;&gt;-->
                     <!--{% set request_data = ( req | get_request_data_chronologically ) %}-->

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -288,17 +288,16 @@
                                     {% endif %}
                                 </div>
                             </div>
-                        {% if current_user.is_authenticated %}
-                            <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
-                                {% if req.agencyDescription != None %}
-                                    {{ req.agencyDescription }}
 
-                                {% endif %}
-                            </p>
-                        {% endif %}
                         </fieldset>
+                        {% endif %}
+                        <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
+                            {% if req.agencyDescription != None %}
+                                Agency Description: {{ req.agencyDescription }}
+                            {% endif %}
+                        </p>
                     </form>
-                    {% endif %}
+
                         </div>
                 <!--<div>-->
                     <!--&lt;!&ndash; shows any existing Q&A or public notes &ndash;&gt;-->
@@ -338,25 +337,27 @@
                     <!--{% endif %}-->
                 <!--</div>-->
             </div>
-            <form name="agency_description" id="agencyDescription" method="post" action="/agencyDescription">
-                <input type="hidden" name="request_id" value="{{ req.id }}"/>
-                <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
-                <fieldset>
-                    <div class="row-fluid" style="width:98%;">
-                        <div class="control-group">
-                            <div class="controls">
-                                <button type="submit"
-                                        class="btn btn-default btn-level"
-                                        data-toggle="modal"
-                                        data-target="#confirm-submit"
-                                        id="editAgencyDescriptionButton">Edit Agency Description
-                                </button>
+            {% if current_user.is_authenticated %}
+                <form name="agency_description" id="agencyDescription" method="post" action="/agencyDescription">
+                    <input type="hidden" name="request_id" value="{{ req.id }}"/>
+                    <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
+                    <fieldset>
+                        <div class="row-fluid" style="width:98%;">
+                            <div class="control-group">
+                                <div class="controls">
+                                    <button type="submit"
+                                            class="btn btn-default btn-level"
+                                            data-toggle="modal"
+                                            data-target="#confirm-submit"
+                                            id="editAgencyDescriptionButton">Edit Agency Description
+                                    </button>
+                                </div>
+                                <input type="hidden" name="agency_description" value="1"/>
                             </div>
-                            <input type="hidden" name="agency_description" value="1"/>
                         </div>
-                    </div>
-                </fieldset>
-            </form>
+                    </fieldset>
+                </form>
+            {% endif %}
             {% endblock request %}
         </div>
         {% endblock well %}

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -74,22 +74,21 @@
                 <p class="lead" style="margin-bottom: 0rem;" truncateable="250">
 {#                {{ req.agencyDescription.decode("utf-8") }}#}
 {#                {{ req.agencyDescription.split('') }}#}
-                {% if "missing_record_description" in errors %}
-                    <div class="alert alert-danger" id="missing_agency_description">
-                        {{ errors['missing_record_description'] }}</div>
+                {% if "missing_agency_description_privacy" in errors %}
+                    <div class="alert alert-danger" id="missing_agency_description_privacy">
+                        {{ errors['missing_agency_description_privacy'] }}</div>
                 {% endif %}
+                {% if (current_user.is_authenticated and audience == 'city') or req.agencyDescription_due_date < datetime.now()%}
                     {% if req.agencyDescription != None %}
-{#                        {% if len(bytes.decode(req.agencyDescription)) > 50 %}#}
-{#                        {% if (req.agencyDescription.decode("utf-8")) > 50 %}#}
                         {% if req.agencyDescription.decode("utf-8")|length > 50 %}
                             Agency Description: {{ req.agencyDescription[0:50] }}...
                         {% else %}
                             Agency Description: {{ req.agencyDescription }}
                         {% endif %}
-
                     {% endif %}
+                {% endif %}
                 </p>
-                {% if current_user.is_authenticated and audience == 'city' %}
+                {% if (current_user.is_authenticated and audience == 'city') %}
                     <form name="agency_description" id="agencyDescription" method="post" action="/agencyDescription">
                         <input type="hidden" name="request_id" value="{{ req.id }}"/>
                         <input name=_csrf_token type=hidden value="{{ csrf_token() }}">

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -203,7 +203,7 @@
                     {% if current_user.is_authenticated and audience == 'city' %}
                     <form class="form-horizontal" method="post" action="/changeprivacy">
                         <input type="hidden" name="request_id" value="{{ req.id }}"/>
-                        <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
+                        <input name=_csrf_token type=hidden value="{{ csrf_token() }}"/>
                         <input type="hidden" name="fieldtype" value="title"/>
                         <fieldset>
                             <!-- Multiple Radios (inline) -->
@@ -296,43 +296,9 @@
                                 {% endif %}
                             </p>
                         {% endif %}
-
                         </fieldset>
                     </form>
                     {% endif %}
-                            <form name="agency_Description" id="agencyDescription" method="post" action="/agencyDescription">
-                                <input type="hidden" name="request_id" value="{{ req.id }}"/>
-{#                                <input name=_csrf_token type=hidden value="{{ csrf_token() }}">#}
-                                <fieldset>
-                                    <div class="row-fluid" style="width:98%;">
-{#                                        <div class="control-group">#}
-{#                                            <label class="control-label">Note <span#}
-{#                                                    rel="tooltip" data-toggle="tooltip"#}
-{#                                                    data-placement="right" title=""#}
-{#                                                    data-original-title="{{ 'Add a note' | explain_action }}">#}
-{#                                                <small><i class="icon-info-sign"></i></small>#}
-{#                                                </span></label>#}
-{##}
-{#                                            <div class="controls">#}
-{#                                                <textarea type="text" class="input-xxlarge"#}
-{#                                                          id="noteTextarea" name="note_text"#}
-{#                                                          placeholder="Notes visible to staff only."#}
-{#                                                          required/></textarea>#}
-{#                                            </div>#}
-{#                                        </div>#}
-                                        <div class="control-group">
-                                            <div class="controls">
-                                                <button type="submit"
-                                                        class="btn btn-default btn-level"
-                                                        data-toggle="modal"
-                                                        data-target="#confirm-submit"
-                                                        id="editAgencyDescriptionButton">Edit Agency Description
-                                                </button>
-                                            </div>
-                                            <input type="hidden" name="agency_description" value="1"/>
-                                        </div>
-                                </fieldset>
-                            </form>
                         </div>
                 <!--<div>-->
                     <!--&lt;!&ndash; shows any existing Q&A or public notes &ndash;&gt;-->
@@ -372,6 +338,25 @@
                     <!--{% endif %}-->
                 <!--</div>-->
             </div>
+            <form name="agency_description" id="agencyDescription" method="post" action="/agencyDescription">
+                <input type="hidden" name="request_id" value="{{ req.id }}"/>
+                <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
+                <fieldset>
+                    <div class="row-fluid" style="width:98%;">
+                        <div class="control-group">
+                            <div class="controls">
+                                <button type="submit"
+                                        class="btn btn-default btn-level"
+                                        data-toggle="modal"
+                                        data-target="#confirm-submit"
+                                        id="editAgencyDescriptionButton">Edit Agency Description
+                                </button>
+                            </div>
+                            <input type="hidden" name="agency_description" value="1"/>
+                        </div>
+                    </div>
+                </fieldset>
+            </form>
             {% endblock request %}
         </div>
         {% endblock well %}

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -96,7 +96,7 @@
                                         <button type="submit"
                                                 class="btn btn-default btn-level"
                                                 data-toggle="modal"
-                                                data-target=".agencyDescriptionModal"
+                                                data-target="#agencyDescriptionModal"
                                                 id="editAgencyDescriptionButton">Edit Agency Description
                                         </button>
                                     </div>
@@ -129,7 +129,7 @@
                         </fieldset>
                     </form>
 
-                    <div class="modal fade agencyDescriptionModal" id="confirm-submit2" tabindex="-1" role="dialog"
+                    <div class="modal fade agencyDescriptionModal" id="agencyDescriptionModal" tabindex="-1" role="dialog"
                          aria-labelledby="myModalLabel" aria-hidden="true" style="height: 40em; width:40em;">
                         <div class="modal-dialog">
                             <div class="modal-content">
@@ -140,13 +140,13 @@
                                     <div id="modalquestionDiv">Are you sure you want to make the following question
                                         public and send an email to the requester?
                                     </div>
-                                    <table id="modalQuestionTable" class="table">
-                                        <tr>
-                                            <th>Question</th>
-                                            <td id="question_text"></td>
-                                            <input type="hidden" id="form_id" value=""/>
-                                        </tr>
-                                    </table>
+{#                                    <table id="modalQuestionTable" class="table">#}
+{#                                        <tr>#}
+{#                                            <th>Question</th>#}
+{#                                            <td id="question_text"></td>#}
+{#                                            <input type="hidden" id="form_id" value=""/>#}
+{#                                        </tr>#}
+{#                                    </table>#}
 
                                     <table id="modalAdditionalInfoTable" class="table">
                                         <tr id="editAgencyDescription" style="display:None;">
@@ -182,8 +182,8 @@
                                     </table>
                                 </div>
                                 <div class="modal-footer">
-                                    <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDescription">Cancel</button>
-                                    <a href="#" id="submit" class="btn btn-success success">Submit</a>
+                                    <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDescription">Canceled</button>
+                                    <a href="#" id="submitAgencyDescription" class="btn btn-success success">Submit</a>
                                 </div>
                             </div>
                         </div>
@@ -200,13 +200,13 @@
                                     <div id="modalquestionDiv">Are you sure you want to make the following question
                                         public and send an email to the requester?
                                     </div>
-{#                                    <table id="modalQuestionTable" class="table">#}
-{#                                        <tr>#}
-{#                                            <th>Question</th>#}
-{#                                            <td id="question_text"></td>#}
-{#                                            <input type="hidden" id="form_id" value=""/>#}
-{#                                        </tr>#}
-{#                                    </table>#}
+                                    <table id="modalQuestionTable" class="table">
+                                        <tr>
+                                            <th>Question</th>
+                                            <td id="question_text"></td>
+                                            <input type="hidden" id="form_id" value=""/>
+                                        </tr>
+                                    </table>
 
                                     <table id="modalAdditionalInfoTable" class="table">
 {#                                        <tr id="editAgencyDescription" style="display:None;">#}
@@ -244,6 +244,7 @@
                             </div>
                         </div>
                     </div>
+
 
                     <!-- Add a public note form -->
                     {% if not current_user.is_authenticated or audience == 'public' %}

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -133,7 +133,7 @@
                     </form>
 
                     <div class="modal fade agencyDescriptionModal" id="agencyDescriptionModal" tabindex="-1" role="dialog"
-                         aria-labelledby="myModalLabel" aria-hidden="true" style="height: 40em; width:40em;">
+                         aria-labelledby="myModalLabel" aria-hidden="true" style="height: 40em; width:60em;">
                         <div class="modal-dialog">
                             <div class="modal-content">
                                 <div class="modal-header">

--- a/public_records_portal/templates/case.html
+++ b/public_records_portal/templates/case.html
@@ -289,7 +289,7 @@
                                 </div>
                             </div>
                         <div class="tab-pane" id="agencyDescription">
-                            <form name="agencyDescription" id="agencyDescription" method="post" action="/editAgencyDescription">
+                            <form name="agency_Description" id="agencyDescription" method="post" action="/agencyDescription">
                                 <input type="hidden" name="request_id" value="{{ req.id }}"/>
 {#                                <input name=_csrf_token type=hidden value="{{ csrf_token() }}">#}
                                 <fieldset>
@@ -312,7 +312,7 @@
                                         <div class="control-group">
                                             <div class="controls">
                                                 <button type="submit"
-                                                        class="btn btn-default btn-block"
+                                                        class="btn btn-default btn-level"
                                                         data-toggle="modal"
                                                         data-target="#confirm-submit"
                                                         id="editAgencyDescriptionButton">Edit Agency Description

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -770,6 +770,7 @@ def close(request_id=None):
         template = 'closed.html'
         request_id = request.form['request_id']
         reasons = []
+
         if 'close_reason' in request.form:
             reasons = request.form['close_reason']
         elif 'close_reasons' in request.form:

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -1703,9 +1703,12 @@ def change_category():
 
 @app.route("/agencyDescription", methods=["POST", "GET"])
 def edit_agency_description():
+    errors={}
     req = request.form
     app.logger.info("Editing the agency description")
-    prr.edit_agency_description(request_id=req['request_id'],agency_description_text=req['additional_information'])
+    errors['missing_agency_description_privacy'] = prr.edit_agency_description(request_id=req['request_id'],agency_description_text=req['additional_information'])
+    if errors['missing_agency_description_privacy']:
+        return show_request_for_city(req['request_id'], errors=errors)
     return redirect(url_for('show_request_for_city', request_id=request.form['request_id']))
 
 @app.route("/<page>")

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -1695,6 +1695,9 @@ def change_category():
     category = request.form['category']
     return redirect(render_template('new_request.html'))
 
+@app.route("/editAgencyDescription", methods=["POST", "GET"])
+def edit_agency_description():
+    return redirect(url_for('show_request_for_city', request_id=request.form['request_id']))
 
 @app.route("/<page>")
 def any_page(page):

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -1697,8 +1697,9 @@ def change_category():
 
 @app.route("/agencyDescription", methods=["POST", "GET"])
 def edit_agency_description():
-    # app.logger.info("Editing the agency description")
-
+    req = request.form
+    app.logger.info("Editing the agency description")
+    prr.edit_agency_description(request_id=req['request_id'],agency_description_text=req['additional_information'])
     return redirect(url_for('show_request_for_city', request_id=request.form['request_id']))
 
 @app.route("/<page>")

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -776,7 +776,7 @@ def close(request_id=None):
         elif 'close_reasons' in request.form:
             for close_reason in request.form.getlist('close_reasons'):
                 reasons.append(close_reason)
-        errors['missing_agency_description'] = close_request(request_id=request_id, reasons=reasons, user_id=get_user_id(), request_body=request.form)
+        errors = close_request(request_id=request_id, reasons=reasons, user_id=get_user_id(), request_body=request.form)
         if errors:
             return show_request(request_id, template=template, errors=errors, form='close')
         return show_request(request_id, template=template)
@@ -1687,9 +1687,9 @@ def change_privacy():
 @app.route("/switchRecordPrivacy", methods=["POST", "GET"])
 def switch_record_privacy():
     record = get_obj("Record", request.form['record_id'])
-    privacy = request.form['privacy_setting']
     app.logger.info(
         "Changing Record Privacy for Request %s, Record_Id %s to %s" % (record, request.form['record_id'], privacy))
+    # models.Record.query.filter_by(request_id=).all()
     if record is not None and privacy is not None:
         prr.change_record_privacy(record_id=request.form['record_id'], privacy=privacy)
     record.privacy = not (record.privacy)

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -778,7 +778,7 @@ def close(request_id=None):
                 reasons.append(close_reason)
         errors['missing_agency_description'] = close_request(request_id=request_id, reasons=reasons, user_id=get_user_id(), request_body=request.form)
         if errors:
-            return show_request(request_id, template=template, errors=errors)
+            return show_request(request_id, template=template, errors=errors, form='close')
         return show_request(request_id, template=template)
     return render_template('error.html', message="You can only close from a requests page!")
 
@@ -1672,12 +1672,15 @@ def submit():
 
 @app.route("/changeprivacy", methods=["POST", "GET"])
 def change_privacy():
+    errors = {}
     req = get_obj("Request", request.form['request_id'])
     privacy = request.form['privacy setting']
     field = request.form['fieldtype']
     # field will either be title or description
     app.logger.info("Changing privacy function")
-    prr.change_privacy_setting(request_id=request.form['request_id'], privacy=privacy, field=field)
+    errors = prr.change_privacy_setting(request_id=request.form['request_id'], privacy=privacy, field=field)
+    if errors['missing_agency_description']:
+        return show_request(req.request_id, template='show_request_for_city', errors=errors)
     return redirect(url_for('show_request_for_city', request_id=request.form['request_id']))
 
 

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -766,7 +766,6 @@ def acknowledge_request(resource, passed_recaptcha=False, data=None):
 @app.route("/close", methods=["GET", "POST"])
 @login_required
 def close(request_id=None):
-    errors = {}
     if request.method == 'POST':
         template = 'closed.html'
         request_id = request.form['request_id']

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -766,17 +766,19 @@ def acknowledge_request(resource, passed_recaptcha=False, data=None):
 @app.route("/close", methods=["GET", "POST"])
 @login_required
 def close(request_id=None):
+    errors = {}
     if request.method == 'POST':
         template = 'closed.html'
         request_id = request.form['request_id']
         reasons = []
-
         if 'close_reason' in request.form:
             reasons = request.form['close_reason']
         elif 'close_reasons' in request.form:
             for close_reason in request.form.getlist('close_reasons'):
                 reasons.append(close_reason)
-        close_request(request_id=request_id, reasons=reasons, user_id=get_user_id(), request_body=request.form)
+        errors['missing_agency_description'] = close_request(request_id=request_id, reasons=reasons, user_id=get_user_id(), request_body=request.form)
+        if errors:
+            return show_request(request_id, template=template, errors=errors)
         return show_request(request_id, template=template)
     return render_template('error.html', message="You can only close from a requests page!")
 

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -505,7 +505,7 @@ show_request_for_x.methods = ['GET', 'POST']
 @app.route("/city/request/<string:request_id>")
 @login_required
 @requires_roles('Portal Administrator', 'Agency Administrator', 'Agency Helpers', 'Agency FOIL Officer')
-def show_request_for_city(request_id):
+def show_request_for_city(request_id,errors=None):
     req = get_obj("Request", request_id)
     app.logger.info("Current User Role: %s" % current_user.role)
     if current_user.role == 'Portal Administrator':
@@ -521,7 +521,7 @@ def show_request_for_city(request_id):
         audience = 'public'
         return show_request_for_x(audience, request_id)
 
-    return show_request(request_id=request_id, template="manage_request_%s_less_js.html" % audience)
+    return show_request(request_id=request_id, template="manage_request_%s_less_js.html" % audience, errors=errors)
 
 
 @app.route("/response/<string:request_id>")
@@ -613,7 +613,7 @@ def show_request(request_id, template="manage_request_public.html", errors=None,
                                , errors=errors, form=form, file=file)
     else:
         return render_template(template, req=req, agency_data=agency_data, users=users,
-                               department=department, assigned_user=assigned_user, helpers=helpers, audience=audience)
+                               department=department, assigned_user=assigned_user, helpers=helpers, audience=audience, datetime=datetime.now())
 
 
 # @app.route("/api/staff")
@@ -1678,9 +1678,9 @@ def change_privacy():
     field = request.form['fieldtype']
     # field will either be title or description
     app.logger.info("Changing privacy function")
-    errors = prr.change_privacy_setting(request_id=request.form['request_id'], privacy=privacy, field=field)
-    if errors['missing_agency_description']:
-        return show_request(req.request_id, template='show_request_for_city', errors=errors)
+    errors['missing_agency_description_privacy'] = prr.change_privacy_setting(request_id=request.form['request_id'], privacy=privacy, field=field)
+    if errors['missing_agency_description_privacy']:
+        return show_request_for_city(req.id, errors=errors)
     return redirect(url_for('show_request_for_city', request_id=request.form['request_id']))
 
 

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -1697,6 +1697,8 @@ def change_category():
 
 @app.route("/agencyDescription", methods=["POST", "GET"])
 def edit_agency_description():
+    # app.logger.info("Editing the agency description")
+
     return redirect(url_for('show_request_for_city', request_id=request.form['request_id']))
 
 @app.route("/<page>")

--- a/public_records_portal/views.py
+++ b/public_records_portal/views.py
@@ -1695,7 +1695,7 @@ def change_category():
     category = request.form['category']
     return redirect(render_template('new_request.html'))
 
-@app.route("/editAgencyDescription", methods=["POST", "GET"])
+@app.route("/agencyDescription", methods=["POST", "GET"])
 def edit_agency_description():
     return redirect(url_for('show_request_for_city', request_id=request.form['request_id']))
 


### PR DESCRIPTION
Created an agency description box that opens up a Modal that an agency user can type and modify.

Created conditional to check the following:

- If the Title and Description of Request are set to private the "Agency Description" must be filled out.
- "Agency Description" must be filled out if the request is closed if there is a reference to an offline document in one of its records
- Checks if any of the documents are marked as 'Private' or 'Released and Private"