### PR TITLE
Bugfix/OP-504 

### DIFF
--- a/public_records_portal/notifications.py
+++ b/public_records_portal/notifications.py
@@ -362,7 +362,7 @@ def send_email(
     include_unsubscribe_link=True,
     cc_everyone=False,
     attached_files=None,
-    privacy=True,
+    privacy=None
     ):
 
     mail = Mail(app)
@@ -377,7 +377,7 @@ def send_email(
         for file in attached_files:
             if file is not None:
                 file.seek(0)
-                if privacy == u'True':
+                if privacy in [RecordPrivacy.PRIVATE, RecordPrivacy.RELEASED_AND_PRIVATE]:
                     url = app.config['UPLOAD_PRIVATE_LOCAL_FOLDER'] + "/" + file.filename
                 else:
                     url = app.config['UPLOAD_PUBLIC_LOCAL_FOLDER'] + "/" + file.filename


### PR DESCRIPTION
Updated send_emails to pull file from correct folder for email attachments.

[OP-504](https://nycrecords.atlassian.net/browse/OP-504)