### PR TITLE
Bugfix/OP-1041: Reset Presets option when selecting user in Edit User form

### DIFF
--- a/app/templates/response/add_user_request.js.html
+++ b/app/templates/response/add_user_request.js.html
@@ -21,8 +21,9 @@
         });
 
         user.change(function () {
-            if (user.val() != 0) {
-                role.val('2');
+            if (user.val() != 0) {  // if this choice actually pertains to a user
+                // set the role to Anonymous User
+                first.find("#role option:contains('Anonymous User')").prop("selected", true);
                 permission.val(null);
                 options.show();
             } else {

--- a/app/templates/response/add_user_request.js.html
+++ b/app/templates/response/add_user_request.js.html
@@ -8,6 +8,7 @@
         var prev = second.find(".prev");
         var submit = second.find(".submit");
 
+        var options = first.find("#add_options");
         var role = first.find("#role");
         var user = first.find("#user");
         var permission = first.find("#permission");
@@ -20,7 +21,13 @@
         });
 
         user.change(function () {
-            $("#add_options").show();
+            if (user.val() != 0) {
+                options.show();
+                role.val('2');
+                permission.val(null)
+            } else {
+                options.hide()
+            }
         });
 
         next.click(function () {

--- a/app/templates/response/add_user_request.js.html
+++ b/app/templates/response/add_user_request.js.html
@@ -22,9 +22,9 @@
 
         user.change(function () {
             if (user.val() != 0) {
-                options.show();
                 role.val('2');
-                permission.val(null)
+                permission.val(null);
+                options.show();
             } else {
                 options.hide()
             }

--- a/app/templates/response/edit_user_request.js.html
+++ b/app/templates/response/edit_user_request.js.html
@@ -55,10 +55,10 @@
         var options = $("#edit_options");
         user.change(function () {
             if (user.val() != 0) {
-                options.show();
                 if (role.val()) {
                     role.val(0);
                 }
+                options.show();
                 setCurrentPermissions();
             } else {
                 options.hide();

--- a/app/templates/response/edit_user_request.js.html
+++ b/app/templates/response/edit_user_request.js.html
@@ -56,6 +56,9 @@
         user.change(function () {
             if (user.val() != 0) {
                 options.show();
+                if (role.val()) {
+                    role.val(0);
+                }
                 setCurrentPermissions();
             } else {
                 options.hide();


### PR DESCRIPTION
- Reset presets option in add and edit user form when selecting a user.
- When switching users in the add/edit user option:  
    - presets option is reset to `Anonymous User` in the add form
    - permissions field is empty in the add form
    - presets option is reset to empty in the edit form
    - permissions field displays the selected user's permissions
 