### PR TITLE
Bugfix/OP-1173: Actions not showing correct options after Reopen

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -589,6 +589,16 @@ class Requests(db.Model):
             return False
 
     @property
+    def was_reopened(self):
+        return self.responses.join(Determinations).filter(
+            Determinations.dtype == determination_type.REOPENING).first() is not None
+        # try:
+        #     self.responses.join(Determinations).filter(Determinations.dtype == determination_type.REOPENING).first()
+        #     return True
+        # except NoResultFound:
+        #     return False
+
+    @property
     def days_until_due(self):
         return calendar.busdaycount(datetime.utcnow(), self.due_date.replace(hour=23, minute=59, second=59))
 

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -226,7 +226,8 @@ def add_closing(request_id, reason_ids, email_content):
 
     """
     current_request = Requests.query.filter_by(id=request_id).one()
-    if current_request.status != request_status.CLOSED and current_request.was_acknowledged:
+    if current_request.status != request_status.CLOSED and (
+                current_request.was_acknowledged or current_request.was_reopened):
         if current_request.privacy['agency_description'] or not current_request.agency_description:
             reason = "Agency Description must be public and not empty, "
             if current_request.responses.filter(

--- a/app/templates/request/status.html
+++ b/app/templates/request/status.html
@@ -90,7 +90,7 @@
 
     {% endif %}
     <p align="center">
-        {% if not request.was_acknowledged %}
+        {% if not (request.was_acknowledged or request.was_reopened) %}
             Acknowledgment<br>
         {% endif %}
         Due Date: {{ moment(request.due_date).format('MM/DD/YYYY') }}

--- a/app/templates/request/view_request.html
+++ b/app/templates/request/view_request.html
@@ -40,7 +40,7 @@
                     <div class="tabbable tabs-left" id="mobile-toggle">
                         <ul class="nav nav-tabs">
                             {% if request.status != status.CLOSED %}
-                                {% if request.status == status.OPEN or not request.was_acknowledged %}
+                                {% if request.status == status.OPEN or not (request.was_acknowledged or request.was_reopened) %}
                                     {% if permissions['acknowledge'] %}
                                         <li class="active"><a href="#acknowledge-request"
                                                               data-toggle="tab">Acknowledge</a>
@@ -87,7 +87,7 @@
                         </ul>
                         <div class="tab-content content-min-height">
                             {% if request.status != status.CLOSED %}
-                                {% if request.status == status.OPEN  or not request.was_acknowledged %}
+                                {% if request.status == status.OPEN or not (request.was_acknowledged or request.was_reopened) %}
                                     {% if permissions['acknowledge'] %}
                                         <div class="tab-pane active" id="acknowledge-request">
                                             {% include "response/add_acknowledgment.html" %}


### PR DESCRIPTION
After the `was_acknowledged` property was fixed, the Reopening of a request shows "Acknowledgement" and "Denial" as the actions. That is not intended and the actions should be as if the Request is "In Progress".