### PR TITLE
Bugfix/OP-1156: Only create a new user if not an agency user.

### DIFF
--- a/app/auth/utils.py
+++ b/app/auth/utils.py
@@ -103,8 +103,9 @@ def find_user_by_email(email):
     elif current_app.config['USE_OAUTH']:
         return Users.query.filter(
             Users.email == email,
-            Users.auth_user_type != user_type_auth.ANONYMOUS_USER
+            Users.auth_user_type.in_(user_type_auth.AGENCY_USER_TYPES)
         ).first()
+    return None
 
 
 def oauth_user_web_service_request(method="GET"):


### PR DESCRIPTION
When a public user (anonymous or NYC.ID) logs in with a new account
(defined as a new GUID + Auth Type) a new account will be created,
regardless of the email address on the account.
Agency users will be modified if their user account is using the custom
LDAP user type.