### PR TITLE
bugfix/OP-1168: Use Date Received for Sorting Results.

### DIFF
--- a/app/constants/__init__.py
+++ b/app/constants/__init__.py
@@ -1,6 +1,7 @@
 from app.constants import response_type, determination_type
 
 ACKNOWLEDGMENT_DAYS_DUE = 5
+REQUESTER_ACKNOWLEDGMENT_DAYS_DUE = 4
 
 CATEGORIES = [
     ('', 'All'),

--- a/app/models.py
+++ b/app/models.py
@@ -658,6 +658,9 @@ class Requests(db.Model):
                 'agency_description_private': not self.agency_description_released,
                 'date_created': self.date_created.strftime(ES_DATETIME_FORMAT),
                 'date_submitted': self.date_submitted.strftime(ES_DATETIME_FORMAT),
+                'date_received': self.date_created.strftime(
+                    ES_DATETIME_FORMAT) if self.date_created < self.date_submitted else self.date_submitted.strftime(
+                    ES_DATETIME_FORMAT),
                 'date_due': self.due_date.strftime(ES_DATETIME_FORMAT),
                 'submission': self.submission,
                 'status': self.status,

--- a/app/request/utils.py
+++ b/app/request/utils.py
@@ -23,6 +23,7 @@ from app.constants import (
     event_type,
     role_name as role,
     ACKNOWLEDGMENT_DAYS_DUE,
+    REQUESTER_ACKNOWLEDGMENT_DAYS_DUE,
     user_type_request,
 )
 from app.constants.response_privacy import RELEASE_AND_PRIVATE
@@ -111,7 +112,7 @@ def create_request(title,
     # 4b. Calculate Request Due Date (month day year but time is always 5PM, 5 Days after submitted date)
     due_date = get_due_date(
         date_submitted_local,
-        ACKNOWLEDGMENT_DAYS_DUE,
+        ACKNOWLEDGMENT_DAYS_DUE if current_user.is_agency else REQUESTER_ACKNOWLEDGMENT_DAYS_DUE,
         tz_name)
 
     date_created = local_to_utc(date_created_local, tz_name)

--- a/app/search/utils.py
+++ b/app/search/utils.py
@@ -302,19 +302,19 @@ def search_requests(query,
     if any((date_rec_from, date_rec_to, date_due_from, date_due_to)):
         range_filters = {}
         if date_rec_from or date_rec_to:
-            range_filters['date_submitted'] = {'format': ES_DATE_RANGE_FORMAT}
+            range_filters['date_received'] = {'format': ES_DATE_RANGE_FORMAT}
         if date_due_from or date_due_to:
             range_filters['date_due'] = {'format': ES_DATE_RANGE_FORMAT}
         if date_rec_from:
-            range_filters['date_submitted']['gte'] = datestr_local_to_utc(date_rec_from)
+            range_filters['date_received']['gte'] = datestr_local_to_utc(date_rec_from)
         if date_rec_to:
-            range_filters['date_submitted']['lt'] = datestr_local_to_utc(date_rec_to)
+            range_filters['date_received']['lt'] = datestr_local_to_utc(date_rec_to)
         if date_due_from:
             range_filters['date_due']['gte'] = datestr_local_to_utc(date_due_from)
         if date_due_to:
             range_filters['date_due']['lt'] = datestr_local_to_utc(date_due_to)
         if date_rec_from or date_rec_to:
-            date_ranges.append({'range': {'date_submitted': range_filters['date_submitted']}})
+            date_ranges.append({'range': {'date_received': range_filters['date_received']}})
         if date_due_from or date_due_to:
             date_ranges.append({'range': {'date_due': range_filters['date_due']}})
 

--- a/app/search/utils.py
+++ b/app/search/utils.py
@@ -120,11 +120,15 @@ def create_index():
                         "date_created": {
                             "type": "date",
                             "format": "strict_date_hour_minute_second",
+                        },
+                        "date_received": {
+                            "type": "date",
+                            "format": "strict_date_hour_minute_second",
                         }
                     }
                 }
             }
-        },
+        }
     )
 
 
@@ -138,6 +142,9 @@ def create_docs():
     operations = []
     for r in requests:
         if r.agency.is_active:
+            date_received = r.date_created.strftime(
+                ES_DATETIME_FORMAT) if r.date_created < r.date_submitted else r.date_submitted.strftime(
+                ES_DATETIME_FORMAT)
             operations.append({
                 '_op_type': 'create',
                 '_id': r.id,
@@ -149,6 +156,7 @@ def create_docs():
                 'agency_description_private': not r.agency_description_released,
                 'date_created': r.date_created.strftime(ES_DATETIME_FORMAT),
                 'date_submitted': r.date_submitted.strftime(ES_DATETIME_FORMAT),
+                'date_received': date_received,
                 'date_due': r.due_date.strftime(ES_DATETIME_FORMAT),
                 'submission': r.submission,
                 'status': r.status,
@@ -195,7 +203,7 @@ def search_requests(query,
                     overdue,
                     size,
                     start,
-                    sort_date_submitted,
+                    sort_date_received,
                     sort_date_due,
                     sort_title,
                     tz_name,
@@ -214,8 +222,8 @@ def search_requests(query,
     :param agency_description: search by agency description?
     :param description: search by description?
     :param requester_name: search by requester name?
-    :param date_rec_from: date received/submitted from
-    :param date_rec_to: date received/submitted to
+    :param date_rec_from: date created/submitted from
+    :param date_rec_to: date created/submitted to
     :param date_due_from: date due from
     :param date_due_to: date due to
     :param agency_ein: agency ein to filter by
@@ -226,7 +234,7 @@ def search_requests(query,
     :param overdue: filter by overdue requests?
     :param size: number of requests per page
     :param start: starting index of request result set
-    :param sort_date_submitted: date received/submitted sort direction
+    :param sort_date_received: date created/submitted sort direction
     :param sort_date_due: date due sort direction
     :param sort_title: title sort direction
     :param tz_name: timezone name (e.g. "America/New_York")
@@ -254,7 +262,7 @@ def search_requests(query,
     # set sort (list of "field:direction" pairs)
     sort = [
         ':'.join((field, direction)) for field, direction in {
-            'date_submitted': sort_date_submitted,
+            'date_received': sort_date_received,
             'date_due': sort_date_due,
             'title.keyword': sort_title}.items() if direction in ("desc", "asc")]
 
@@ -357,6 +365,7 @@ def search_requests(query,
         _source=['requester_id',
                  'date_submitted',
                  'date_due',
+                 'date_received',
                  'date_created',
                  'status',
                  'agency_ein',
@@ -506,7 +515,7 @@ def convert_dates(results, dt_format=None, tz_name=None):
     :tz_name: time zone name
     """
     for hit in results["hits"]["hits"]:
-        for field in ("date_submitted", "date_due", "date_created"):
+        for field in ("date_submitted", "date_due", "date_received"):
             dt = datetime.strptime(hit["_source"][field], ES_DATETIME_FORMAT)
             if tz_name:
                 dt = utc_to_local(dt, tz_name)
@@ -530,12 +539,12 @@ def _process_highlights(results, requester_id=None):
                             if requester_id
                             else False)
             if ('title' in hit['highlight']
-               and hit['_source']['title_private']
-               and (current_user.is_anonymous or not is_requester)):
+                and hit['_source']['title_private']
+                and (current_user.is_anonymous or not is_requester)):
                 hit['highlight'].pop('title')
             if ('agency_description' in hit['highlight']
-               and hit['_source']['agency_description_private']):
+                and hit['_source']['agency_description_private']):
                 hit['highlight'].pop('agency_description')
             if ('description' in hit['highlight']
-               and not is_requester):
+                and not is_requester):
                 hit['highlight'].pop('description')

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -44,7 +44,7 @@ def requests():
     All Users can filter by:
     - Status, Open (anything not Closed if not agency user)
     - Status, Closed
-    - Date Received
+    - Date Submitted
     - Agency
 
     Only Agency Users can filter by:

--- a/app/templates/request/_agency_search_form.html
+++ b/app/templates/request/_agency_search_form.html
@@ -46,7 +46,7 @@
 </div>
 <div class="col-sm-4">
     <div class="row">
-        <h4><label>Date Received*</label>
+        <h4><label>Date Submitted*</label>
             <small data-toggle="popover" data-placement="top" data-trigger="hover" title="Date Received"
                    data-content="This field allows you to search for requests that were received between two specific dates.">
                 <span class="glyphicon glyphicon-question-sign"></span>

--- a/app/templates/request/_public_search_form.html
+++ b/app/templates/request/_public_search_form.html
@@ -55,7 +55,7 @@
         <strong>&nbsp;Results Per Page</strong>
     </div>
     <div class="col-sm-3">
-        <h4><label>Date Received*</label>
+        <h4><label>Date Submitted*</label>
             <small data-toggle="popover" data-placement="top" data-trigger="hover" title="Date Received"
                    data-content="This field allows you to search for requests that were received between
                                                     two specific dates.">

--- a/app/templates/request/all.html
+++ b/app/templates/request/all.html
@@ -64,7 +64,7 @@
                             ID
                         </div>
                         <div class="col-sm-2 sort-field" data-sort-order="none" id="sort_date_submitted">
-                            Date Received <span class="glyphicon" aria-hidden="true"></span>
+                            Date Submitted <span class="glyphicon" aria-hidden="true"></span>
                         </div>
                         <div class="col-sm-{% if current_user.is_agency %}2{% else %}3{% endif %} sort-field"
                              data-sort-order="none" id="sort_title">

--- a/app/templates/request/result_row.html
+++ b/app/templates/request/result_row.html
@@ -24,7 +24,7 @@
                 {{ request._id }}
             </div>
             <div class="col-sm-2">
-                {{ moment(request._source.date_submitted).format('MMM DD, YYYY') }}
+                {{ moment(request._source.date_received).format('MMM DD, YYYY') }}
             </div>
             <div class="col-sm-{% if current_user.is_agency %}2{% else %}3{% endif %}">
                 {% if current_user.is_agency %}
@@ -45,6 +45,7 @@
                 </div>
             {% endif %}
         </div>
+    {% if config['TESTING'] %}
     <!-- Only for testing -->
 {#        <div class="test-info">#}
 {#            <div class="row">#}
@@ -97,5 +98,6 @@
 {#                </div>#}
 {#            </div>#}
 {#        </div>#}
+    {% endif %}
     </a>
 {% endfor %}


### PR DESCRIPTION
Change frontend to Display "Date Submitted" rather than "Date Received".

Changed backend to search and sort by "date_created" rather than
"date_submitted".