### PR TITLE
Feature/OP-1172: Add FOIL ID to Basic Search

### DIFF
--- a/app/search/utils.py
+++ b/app/search/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 
 from flask import current_app
 from flask_login import current_user
@@ -257,7 +258,7 @@ def search_requests(query,
 
     # if searching by foil-id, strip "FOIL-"
     if foil_id:
-        query = query.lstrip("FOIL-")
+        query = query.lstrip("FOIL-").lstrip('foil-')
 
     # set sort (list of "field:direction" pairs)
     sort = [

--- a/app/search/utils.py
+++ b/app/search/utils.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import re
 
 from flask import current_app
 from flask_login import current_user

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -73,7 +73,7 @@ def requests():
     query = request.args.get('query')
 
     # Determine if searching for FOIL ID
-    foil_id = eval_request_bool(request.args.get('foil_id')) or re.match(r'^(FOIL|foil)-\d{4}-\d{3}-\d{5}$', query)
+    foil_id = eval_request_bool(request.args.get('foil_id')) or re.match(r'^(FOIL-|foil-|)\d{4}-\d{3}-\d{5}$', query)
 
     results = search_requests(
         query,

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import datetime
 from io import StringIO, BytesIO
+import re
 
 from flask import (
     request,
@@ -70,9 +71,13 @@ def requests():
         start = 0
 
     query = request.args.get('query')
+
+    # Determine if searching for FOIL ID
+    foil_id = eval_request_bool(request.args.get('foil_id')) or re.match(r'^(FOIL|foil)-\d{4}-\d{3}-\d{5}$', query)
+
     results = search_requests(
         query,
-        eval_request_bool(request.args.get('foil_id')),
+        foil_id,
         eval_request_bool(request.args.get('title')),
         eval_request_bool(request.args.get('agency_description')),
         eval_request_bool(request.args.get('description')) if not current_user.is_anonymous else False,


### PR DESCRIPTION
Add ability to search for FOIL ID without checking filter option.

This commit adds the ability for users to search for a request via FOIL ID from
the basic search box without having to open the advanced search options.

FOIL ID must match the following regular expression:
```
     ^(FOIL-|foil-|)\d{4}-\d{3}-\d{5}$
```

Valid Matches:
```
      FOIL-2017-860-00001
      foil-2017-860-00001
      2017-860-00001
```

If it matches, then the search will be carried out only on the FOIL ID.