### PR TITLE
Bugfix/OP-1197: Adding file email confirmation window

### DIFF
--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -879,12 +879,11 @@ def _file_email_handler(request_id, data, page, agency_name, email_template):
     release_private_links = []
 
     release_date = None
-    request = None
+    request = Requests.query.filter_by(id=request_id).one()
 
     files = data.get('files')
     # if data['files'] exists, use email_content as template with specific file email template
     if files is not None:
-        request = Requests.query.filter_by(id=request_id).one()
         files = json.loads(files)
         default_content = True
         content = None
@@ -920,7 +919,7 @@ def _file_email_handler(request_id, data, page, agency_name, email_template):
                                                 agency_name=agency_name,
                                                 agency_default_email=request.agency.default_email,
                                                 public_requester=request.requester.auth_user_type in
-                                                                    user_type_auth.PUBLIC_USER_TYPES,
+                                                                 user_type_auth.PUBLIC_USER_TYPES,
                                                 release_date=release_date,
                                                 release_public_links=release_public_links,
                                                 release_private_links=release_private_links,

--- a/app/templates/email_templates/email_response_file.html
+++ b/app/templates/email_templates/email_response_file.html
@@ -25,10 +25,22 @@
                         </li>
                     {% endfor %}
                 </ul>
+            {% if release_private_links %}
+                <p>
+                    The file(s) listed below will not be publicly available on the OpenRecords portal.
+                </p>
+                <ul>
+                    {% for file in release_private_links %}
+                        <li style="list-style: none">
+                            {{ file['title'] }}: <a href="{{ file['link'] }}">{{ file['filename'] }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
             </div>
         {% endif %}
 
-        {% if release_private_links %}
+        {% if release_private_links and not release_public_links %}
             <p>
                 The file(s) listed below will not be publicly available on the OpenRecords portal.
             </p>

--- a/app/templates/email_templates/response_file_links.html
+++ b/app/templates/email_templates/response_file_links.html
@@ -1,5 +1,5 @@
 {% if not private_links %}
-    {% if release_public_links and not release_private_links %}
+    {% if release_public_links %}
         <ul>
             {% for file in release_public_links %}
                 <li style="list-style: none">
@@ -7,31 +7,21 @@
                 </li>
             {% endfor %}
         </ul>
-    {% endif %}
-    {% if release_private_links and not release_public_links %}
-        <ul>
-            {% for file in release_private_links %}
-                <li style="list-style: none">
-                    {{ file['title'] }}: <a href="{{ file['link'] }}">{{ file['filename'] }}</a>
-                </li>
-            {% endfor %}
-        </ul>
+        {% if release_private_links %}
+            <p>
+                The file(s) listed below will not be publicly available on the OpenRecords portal.
+            </p>
+            <ul>
+                {% for file in release_private_links %}
+                    <li style="list-style: none">
+                        {{ file['title'] }}: <a href="{{ file['link'] }}">{{ file['filename'] }}</a>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
     {% endif %}
 
-    {% if release_public_links and release_private_links %}
-        <ul>
-            {% for file in release_public_links %}
-                <li style="list-style: none">
-                    {{ file['title'] }}: <a href="{{ file['link'] }}">{{ file['filename'] }}</a>
-                </li>
-            {% endfor %}
-        </ul>
-        <p>
-            The links below will be valid until {{ release_date }}.
-            The records accessed through these links will not be publicly accessible. If you need to access these
-            files after this date, please contact the {{ agency_name }} at
-            <a href="mailto:{{ agency_default_email }}">{{ agency_default_email }}</a>
-        </p>
+    {% if release_private_links and not release_public_links %}
         <ul>
             {% for file in release_private_links %}
                 <li style="list-style: none">


### PR DESCRIPTION
Confirmation dialogue for add file workflow was broken per [fb5773ecfbd02959621350d40ff4d9ee723bb133](https://github.com/CityOfNewYork/NYCOpenRecords/commit/fb5773ecfbd02959621350d40ff4d9ee723bb133).
On the rendering of the confirmation template, request is `None` and thus `agency_default_email` is None as well causing the template to not render.

This also includes fixes to file links generating multiple times if there are both release and public and release and private files. 