### PR TITLE
Standardize Email Capitalization for User Queries

### DIFF
--- a/app/auth/utils.py
+++ b/app/auth/utils.py
@@ -114,8 +114,9 @@ def find_user_by_email(email):
         ).first()
         return user if user.agencies.all() else None
     elif current_app.config['USE_OAUTH']:
+        from sqlalchemy import func
         return Users.query.filter(
-            Users.email == email,
+            func.lower(Users.email) == email.lower(),
             Users.auth_user_type.in_(user_type_auth.AGENCY_USER_TYPES)
         ).first()
     return None


### PR DESCRIPTION
When querying for a user by their email we now standardize the email to be lowercase to ensure we can find the users record. This is mostly used on the initial login when converting a user from the v2.0 LDAP User AuthType to the SAML User Auth type used in v2.1