### PR TITLE
hotfix/OP-1303: Add Link to Files Submitted with Request

### DIFF
--- a/app/request/utils.py
+++ b/app/request/utils.py
@@ -270,10 +270,10 @@ def create_request(title,
     # 13. Add all parent agency administrators to the request.
     if agency != agency.parent:
         if (
-                                agency.parent.agency_features is not None and
-                                agency_ein in agency.parent.agency_features.get('monitor_agency_requests', []) and
-                        agency.parent.is_active and
-                    agency.parent.administrators
+            agency.parent.agency_features is not None and
+            agency_ein in agency.parent.agency_features.get('monitor_agency_requests', []) and
+            agency.parent.is_active and
+            agency.parent.administrators
         ):
             _create_agency_user_requests(request_id=request_id,
                                          agency_admins=agency.parent.administrators,

--- a/app/request/utils.py
+++ b/app/request/utils.py
@@ -439,7 +439,7 @@ def send_confirmation_email(request, agency, user):
     release_public, release_private, private = ([] for i in range(3))
     if file_response is not None:
         get_file_links(file_response, release_public, release_private, private)
-    file = release_private[0] if len(release_private) > 0 else None
+    file_link = release_private[0] if len(release_private) > 0 else None
 
     # generates the view request page URL for this request
     if agency.is_active:
@@ -458,7 +458,7 @@ def send_confirmation_email(request, agency, user):
                                     agency_default_email=agency_default_email,
                                     user=user,
                                     address=address,
-                                    file=file,
+                                    file_link=file_link,
                                     page=page)
 
     try:

--- a/app/request/utils.py
+++ b/app/request/utils.py
@@ -25,6 +25,7 @@ from app.constants import (
     ACKNOWLEDGMENT_DAYS_DUE,
     REQUESTER_ACKNOWLEDGMENT_DAYS_DUE,
     user_type_request,
+    response_type
 )
 from app.constants.response_privacy import (
     RELEASE_AND_PRIVATE,
@@ -54,9 +55,13 @@ from app.models import (
     UserRequests,
     Roles,
     Files,
-    ResponseTokens
+    ResponseTokens,
+    Responses,
 )
-from app.response.utils import safely_send_and_add_email
+from app.response.utils import (
+    safely_send_and_add_email,
+    get_file_links
+)
 from app.upload.constants import upload_status
 from app.upload.utils import (
     is_valid_file_type,
@@ -265,10 +270,10 @@ def create_request(title,
     # 13. Add all parent agency administrators to the request.
     if agency != agency.parent:
         if (
-            agency.parent.agency_features is not None and
-            agency_ein in agency.parent.agency_features.get('monitor_agency_requests', []) and
-            agency.parent.is_active and
-            agency.parent.administrators
+                                agency.parent.agency_features is not None and
+                                agency_ein in agency.parent.agency_features.get('monitor_agency_requests', []) and
+                        agency.parent.is_active and
+                    agency.parent.administrators
         ):
             _create_agency_user_requests(request_id=request_id,
                                          agency_admins=agency.parent.administrators,
@@ -429,6 +434,13 @@ def send_confirmation_email(request, agency, user):
     requester_email = user.email
     address = user.mailing_address
 
+    # gets the file link, if a file was provided.
+    file_response = request.responses.filter(Responses.type == response_type.FILE).one_or_none()
+    release_public, release_private, private = ([] for i in range(3))
+    if file_response is not None:
+        get_file_links(file_response, release_public, release_private, private)
+    file = release_private[0] if len(release_private) > 0 else None
+
     # generates the view request page URL for this request
     if agency.is_active:
         page = urljoin(flask_request.host_url, url_for('request.view', request_id=request.id))
@@ -446,6 +458,7 @@ def send_confirmation_email(request, agency, user):
                                     agency_default_email=agency_default_email,
                                     user=user,
                                     address=address,
+                                    file=file,
                                     page=page)
 
     try:

--- a/app/request/views.py
+++ b/app/request/views.py
@@ -24,7 +24,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from app.constants import (
     request_status,
     permission,
-    response_type
 )
 from app.lib.date_utils import (
     DEFAULT_YEARS_HOLIDAY_LIST,

--- a/app/request/views.py
+++ b/app/request/views.py
@@ -23,7 +23,8 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app.constants import (
     request_status,
-    permission
+    permission,
+    response_type
 )
 from app.lib.date_utils import (
     DEFAULT_YEARS_HOLIDAY_LIST,
@@ -148,6 +149,7 @@ def new():
 
         current_request = Requests.query.filter_by(id=request_id).first()
         requester = current_request.requester
+
         send_confirmation_email(request=current_request, agency=current_request.agency, user=requester)
 
         if current_request.agency.is_active:

--- a/app/templates/email_templates/email_confirmation.html
+++ b/app/templates/email_templates/email_confirmation.html
@@ -18,7 +18,11 @@
                                     Request Description: {{ current_request.description }}
                                     <br/>
                                     <br/>
-
+                                    {% if file %}
+                                        Attached File: {{ file['title'] }}: <a href="{{ file['link'] }}">{{ file['filename'] }}
+                                        <br/>
+                                        <br/>
+                                    {% endif %}
                                     <p style="text-decoration: underline">Requester's Contact Information</p>
                                     <div class="row-fluid hide" id="requester_info">
                                         <div>

--- a/app/templates/email_templates/email_not_onboarded.html
+++ b/app/templates/email_templates/email_not_onboarded.html
@@ -20,7 +20,11 @@
                                     Request Description: {{ current_request.description }}
                                     <br/>
                                     <br/>
-
+                                    {% if file %}
+                                        Attached File: {{ file['title'] }}: <a href="{{ file['link'] }}">{{ file['filename'] }}
+                                        <br/>
+                                        <br/>
+                                    {% endif %}
                                     <p style="text-decoration: underline">Requester's Contact Information</p>
                                     <div class="row-fluid hide" id="requester_info">
                                         <div>


### PR DESCRIPTION
Add a file link to the email confirmation / receipt sent out to the agency and requester when a request is submitted on OpenRecords. This only applies when a file has been added to the request. The link contains a token for the release and private file that the requester has provided as part of their request.

The link is the same for agencies that are live on the portal and agencies that have not begun using the portal to respond to FOIL requests.

Signed-off-by: Joel Castillo <jocastillo@records.nyc.gov>