### PR TITLE
Bugfix/OP-1311: Add Error Handling for Anonymous Users and KeyErrors

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -232,11 +232,15 @@ def oauth_logout():
     timed_out = eval_request_bool(request.args.get('timeout'))
     forced_logout = eval_request_bool(request.args.get('forced_logout'))
     if forced_logout:
-        redis_get_user_session(current_user.session_id).destroy()
+        user_session = redis_get_user_session(current_user.session_id)
+        if user_session is not None:
+            user_session.destroy()
     if timed_out:
         flash("Your session timed out. Please login again", category='info')
     if 'token' in session:
         revoke_and_remove_access_token()
+    if current_user.is_anonymous:
+        return redirect(url_for("main.index"))
     update_object({'session_id': None}, Users, (current_user.guid, current_user.auth_user_type))
     logout_user()
     session.destroy()

--- a/app/lib/redis_utils.py
+++ b/app/lib/redis_utils.py
@@ -64,12 +64,16 @@ def redis_get_user_session(session_id):
     serialization_method = pickle
     session_class = KVSession
 
-    s = session_class(serialization_method.loads(
-        current_app.kvsession_store.get(session_id)
-    ))
-    s.sid_s = session_id
+    try:
+        s = session_class(serialization_method.loads(
+            current_app.kvsession_store.get(session_id)
+        ))
+        s.sid_s = session_id
 
-    return s
+        return s
+
+    except KeyError:
+        return None
 
 
 def redis_delete_user_session(session_id):


### PR DESCRIPTION
Added a check for a KeyError when trying to delete a session. If the
session does not exist, Redis will raise a KeyError. This means we don't
need to destroy the session and can just move on.

Additionally, if the current_user is anonymous, we don't need to do any
database modifications, because the user does not exist in the Users
table. THerefore we can just redirect to the home page when they click
logout.

Signed-off-by: Joel Castillo <jocastillo@records.nyc.gov>