### PR TITLE
Bugfix/OP-1304: Duplicate File Uploads Fix

### DIFF
--- a/app/lib/utils.py
+++ b/app/lib/utils.py
@@ -9,7 +9,9 @@ from base64 import b64decode
 class InvalidUserException(Exception):
     def __init__(self, user):
         """
-        :param user: the current_user as define in flask_login
+        Exception used when an invalid user is detected.
+
+        :param user: the current_user as defined in flask_login
         """
         super(InvalidUserException, self).__init__(
             "Invalid user: {}".format(user))
@@ -18,10 +20,27 @@ class InvalidUserException(Exception):
 class UserRequestException(Exception):
     def __init__(self, action, request_id, reason):
         """
-        :param request_id: request that was not closed
+        Exception used to handle errors performing actions on a request.
+
+        :param action: Action attempted
+        :param request_id: Unique request identifier
+        :param reason: Description of failure reason
         """
         super(UserRequestException, self).__init__(
             'Unable to {} request: {}\nReason: {}'.format(action, request_id, reason)
+        )
+
+
+class DuplicateFileException(Exception):
+    def __init__(self, file_name, request_id):
+        """
+        Exception used when a duplicate file is added to a request.
+
+        :param file_name: Name of file uploaded
+        :param request_id: Unique request identifier
+        """
+        super(DuplicateFileException, self).__init__(
+            "{} has already been uploaded to {}".format(file_name, request_id)
         )
 
 

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -118,8 +118,6 @@ def add_file(request_id, filename, title, privacy, is_editable):
         return str(e)
 
 
-
-
 def add_note(request_id, note_content, email_content, privacy, is_editable, is_requester):
     """
     Create and store the note object for the specified request.

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -56,7 +56,7 @@ from app.lib.date_utils import (
 from app.lib.db_utils import create_object, update_object, delete_object
 from app.lib.email_utils import send_email, get_agency_emails
 from app.lib.redis_utils import redis_get_file_metadata, redis_delete_file_metadata
-from app.lib.utils import eval_request_bool, UserRequestException
+from app.lib.utils import eval_request_bool, UserRequestException, DuplicateFileException
 from app.models import (
     Events,
     Notes,
@@ -98,21 +98,26 @@ def add_file(request_id, filename, title, privacy, is_editable):
         mime_type = fu.get_mime_type(path)
         hash_ = fu.get_hash(path)
 
-    response = Files(
-        request_id,
-        privacy,
-        title,
-        filename,
-        mime_type,
-        size,
-        hash_,
-        is_editable=is_editable
-    )
-    create_object(response)
+    try:
+        response = Files(
+            request_id,
+            privacy,
+            title,
+            filename,
+            mime_type,
+            size,
+            hash_,
+            is_editable=is_editable
+        )
+        create_object(response)
 
-    create_response_event(event_type.FILE_ADDED, response)
+        create_response_event(event_type.FILE_ADDED, response)
 
-    return response
+        return response
+    except DuplicateFileException as e:
+        return str(e)
+
+
 
 
 def add_note(request_id, note_content, email_content, privacy, is_editable, is_requester):

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -130,7 +130,6 @@ def response_file(request_id):
     release_public_links = []
     release_private_links = []
     private_links = []
-    errors = []
     for file_data in files:
         response_obj = add_file(current_request.id,
                                 file_data,

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -130,13 +130,17 @@ def response_file(request_id):
     release_public_links = []
     release_private_links = []
     private_links = []
+    errors = []
     for file_data in files:
         response_obj = add_file(current_request.id,
                                 file_data,
                                 files[file_data]['title'],
                                 files[file_data]['privacy'],
                                 is_editable=True)
-        get_file_links(response_obj, release_public_links, release_private_links, private_links)
+        if not isinstance(response_obj, Files):
+            flash(message=response_obj, category='danger')
+        else:
+            get_file_links(response_obj, release_public_links, release_private_links, private_links)
     send_file_email(request_id,
                     release_public_links,
                     release_private_links,


### PR DESCRIPTION
Add Duplicate File Check in Files class

Added a new exception `DuplicateFileException` which is raised when a
file is uploaded to a request a second time. This is used in a new check
in the constructor for the Files class in models.py to ensure that a
file is not uploaded twice. This is done to prevent a second email from
being sent out to the requester when a file is uploaded twice due to a
race condition with the Redis keystore.

If a file is uploaded twice, the upload will go through with all valid
files, but any file that was not successfully uploaded will display an
alert at the top of the page after the form has been submitted.
