### PR TITLE
Feature/OP-1329: Email footer reimplementation

### DIFF
--- a/app/templates/email_templates/email_edit_file.html
+++ b/app/templates/email_templates/email_edit_file.html
@@ -151,5 +151,5 @@
     <p>
         Please visit <a href='{{ page }}'>{{ page }}</a> to view additional information and take any necessary action.
     </p>
-    <p><br></p>
+    {% include "email_templates/email_footer.html" %}
 {% endblock %}

--- a/app/templates/email_templates/email_edit_private_response.html
+++ b/app/templates/email_templates/email_edit_private_response.html
@@ -28,6 +28,5 @@
             <span class="mceNonEditable"> {{ response_data.data_new[key] }} </span>
         </p>
     {% endif %}
-    <p><br /></p>
+    {% include "email_templates/email_footer.html" %}
 {% endfor %}
-{% include "email_templates/email_footer.html" %}

--- a/app/templates/email_templates/email_edit_response.html
+++ b/app/templates/email_templates/email_edit_response.html
@@ -55,6 +55,5 @@
     <p>
         Please visit <a href='{{ page }}'>{{ page }}</a> to view additional information and take any necessary action.
     </p>
-    <p><br></p>
     {% include "email_templates/email_footer.html" %}
 {% endblock %}

--- a/app/templates/email_templates/email_edit_response.html
+++ b/app/templates/email_templates/email_edit_response.html
@@ -56,4 +56,5 @@
         Please visit <a href='{{ page }}'>{{ page }}</a> to view additional information and take any necessary action.
     </p>
     <p><br></p>
+    {% include "email_templates/email_footer.html" %}
 {% endblock %}

--- a/app/templates/email_templates/email_footer.html
+++ b/app/templates/email_templates/email_footer.html
@@ -1,3 +1,3 @@
-<div class="email-footer">
+<div class="email-footer" style="padding-bottom: 15px">
     <span class="mceNonEditable">DO NOT RESPOND TO THIS EMAIL. For information or questions about this request please use the Contact the Agency link on the request page in OpenRecords.</span>
 </div>

--- a/app/templates/email_templates/email_footer.html
+++ b/app/templates/email_templates/email_footer.html
@@ -1,3 +1,3 @@
 <div class="email-footer">
-    <p>DO NOT RESPOND TO THIS EMAIL. For information or questions about this request please use the Contact the Agency link on the request page in OpenRecords.</p>
+    <span class="mceNonEditable">DO NOT RESPOND TO THIS EMAIL. For information or questions about this request please use the Contact the Agency link on the request page in OpenRecords.</span>
 </div>

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -16,8 +16,7 @@
             {% endfor %}
         </ul>
     </div>
-    <p><br></p>
+    {% include "email_templates/email_footer.html" %}
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}

--- a/app/templates/email_templates/email_request_status_changed.html
+++ b/app/templates/email_templates/email_request_status_changed.html
@@ -77,4 +77,3 @@
         </ul>
     {% endif %}
 </span>
-{% include "email_templates/email_footer.html" %}

--- a/app/templates/email_templates/email_response.html
+++ b/app/templates/email_templates/email_response.html
@@ -7,5 +7,4 @@
     {% endblock %}
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}

--- a/app/templates/email_templates/email_response_acknowledgment.html
+++ b/app/templates/email_templates/email_response_acknowledgment.html
@@ -14,8 +14,7 @@
             Please visit <a href="{{ page }}">{{ request_id }}</a> to view additional information and take any necessary action.
         </span>
     </p>
-    <p><br/></p>
+    {% include "email_templates/email_footer.html" %}
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}

--- a/app/templates/email_templates/email_response_extension.html
+++ b/app/templates/email_templates/email_response_extension.html
@@ -11,8 +11,7 @@
         Please visit <a href="{{ page }}">{{ request_id }}</a> to view additional information and take any necessary action.
         </span>
     </p>
-    <p><br /></p>
+    {% include "email_templates/email_footer.html" %}
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}

--- a/app/templates/email_templates/email_response_file.html
+++ b/app/templates/email_templates/email_response_file.html
@@ -66,8 +66,8 @@
             necessary action.
         </span>
     </p>
+    {% include "email_templates/email_footer.html" %}
     <p><br></p>
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}

--- a/app/templates/email_templates/email_response_instruction.html
+++ b/app/templates/email_templates/email_response_instruction.html
@@ -16,7 +16,7 @@
                 additional information and take any necessary action.
             </span>
         </p>
-        <p><br/></p>
+        {% include "email_templates/email_footer.html" %}
 
     {% elif privacy == response_privacy.RELEASE_AND_PRIVATE %}
         <p>
@@ -30,7 +30,7 @@
                 Please visit <a href="{{ page }}">{{ request_id }}</a> to view additional information and take any necessary action.
             </span>
         </p>
-        <p><br/></p>
+        {% include "email_templates/email_footer.html" %}
 
     {% elif privacy == response_privacy.PRIVATE %}
         <p>Attention {{ agency_name }} Users,</p>
@@ -40,9 +40,8 @@
                 &nbsp;&nbsp;&nbsp;&nbsp;{{ instruction_content }}<br />
             </span>
         </p>
-        <p><br /></p>
+        {% include "email_templates/email_footer.html" %}
     {% endif %}
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}

--- a/app/templates/email_templates/email_response_link.html
+++ b/app/templates/email_templates/email_response_link.html
@@ -16,7 +16,7 @@
                 and take any necessary action.
             </span>
         </p>
-        <p><br/></p>
+        {% include "email_templates/email_footer.html" %}
 
     {% elif privacy == response_privacy.RELEASE_AND_PRIVATE %}
         <p>
@@ -30,7 +30,7 @@
                 necessary action.
             </span>
         </p>
-        <p><br/></p>
+        {% include "email_templates/email_footer.html" %}
 
     {% elif privacy == response_privacy.PRIVATE %}
         <p>Attention {{ agency_name }} Users,</p>
@@ -41,9 +41,8 @@
                 &nbsp;&nbsp;&nbsp;&nbsp;{{ title }}: <a href="{{ url }}">{{ url }}</a><br />
             </span>
         </p>
-        <p><br /></p>
+        {% include "email_templates/email_footer.html" %}
     {% endif %}
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}

--- a/app/templates/email_templates/email_response_note.html
+++ b/app/templates/email_templates/email_response_note.html
@@ -23,7 +23,7 @@
                     necessary action.
                 </span>
             </p>
-            <p><br/></p>
+            {% include "email_templates/email_footer.html" %}
 
         {% elif privacy == response_privacy.RELEASE_AND_PRIVATE %}
             <p>
@@ -36,7 +36,7 @@
                     Please visit <a href="{{ page }}">{{ request_id }}</a> to view additional information and take any necessary action.
                 </span>
             </p>
-            <p><br/></p>
+            {% include "email_templates/email_footer.html" %}
 
         {% elif privacy == response_privacy.PRIVATE %}
             <p>Attention {{ agency_name }} Users,</p>
@@ -46,10 +46,9 @@
                     &nbsp;&nbsp;&nbsp;&nbsp;{{ note_content }}<br/>
                 </span>
             </p>
-            <p><br/></p>
+            {% include "email_templates/email_footer.html" %}
         {% endif %}
     {% endif %}
 {% else %}
     {{ content | safe }}
-    {% include "email_templates/email_footer.html" %}
 {% endif %}


### PR DESCRIPTION
Reimplementation of the email footer because the previous way resulted in too many inconsistencies especially with emails regarding privacy changes. For most templates, the footer will now be visible at the editing stage instead of the confirmation stage but it will not be editable by the user.