### PR TITLE
Fix Multiple Emails for Multi-File Uploads

### DIFF
--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -1330,7 +1330,7 @@ def send_file_email(request_id, release_public_links, release_private_links, pri
                                       email_content_agency,
                                       'File(s) Added to {}'.format(request_id),
                                       bcc=bcc)
-    else:
+    elif private_links:
         email_content_agency = email_content.replace(replace_string,
                                                      render_template('email_templates/response_file_links.html',
                                                                      request_id=request_id,

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -140,13 +140,13 @@ def response_file(request_id):
             flash(message=response_obj, category='danger')
         else:
             get_file_links(response_obj, release_public_links, release_private_links, private_links)
-            send_file_email(request_id,
-                            release_public_links,
-                            release_private_links,
-                            private_links,
-                            flask_request.form['email-file-summary'],
-                            flask_request.form['replace-string'],
-                            flask_request.form['tz_name'])
+    send_file_email(request_id,
+                    release_public_links,
+                    release_private_links,
+                    private_links,
+                    flask_request.form['email-file-summary'],
+                    flask_request.form['replace-string'],
+                    flask_request.form['tz_name'])
     return redirect(url_for('request.view', request_id=request_id))
 
 


### PR DESCRIPTION
Due to a misplaced function call inside of a for loop, when a user uploads multiple files, one email per file was being sent out in the format:
Email 1: File A
Email 2: File A, File B
Email 3: File A, File B, File C
etc...

To resolve this issue, the following changes were made to the `send_file_email` function, which generates the emails for the file upload utility.
Email Generation Conditions
 - "Release and Public" links provided
 - "Release and Private" links provided
 - "Private" links provided
 - "Release and Public" links and "Release and Private" links provided
 - "Release and Public" links and "Private" links provided
 - "Release and Private" links and "Private" links provided
 - "Release and Public" links and "Release and Private" links and "Private" links provided.

Previously even if no links were provided, an email without links could be sent due to an else condition. This condition has been changed to an elif.

Signed-off-by: Joel Castillo <jocastillo@records.nyc.gov>