### PR TITLE
Feature/OP-1241: Use consistent date formatting

### DIFF
--- a/app/request/forms.py
+++ b/app/request/forms.py
@@ -91,7 +91,7 @@ class AgencyUserRequestForm(Form):
     request_agency = SelectField('Agency (required)', choices=None)
     request_title = StringField('Request Title (required)')
     request_description = TextAreaField('Request Description (required)')
-    request_date = DateTimeField("Date (required)", format="%Y-%m-%d", default=datetime.today)
+    request_date = DateTimeField("Date (required)", format="%m/%d/%Y", default=datetime.today)
 
     # Personal Information
     # TODO: when refactoring these classes, include length and other validators

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -59,7 +59,7 @@ $(document).ready(function () {
 
     // Datepicker for date request was received when creating a new request
     $(".dtpick").datepicker({
-        dateFormat: "yy-mm-dd",
+        dateFormat: "mm/dd/yy",
         maxDate: 0
     }).keydown(function (e) {
         // prevent keyboard input except for tab

--- a/app/templates/main/about.html
+++ b/app/templates/main/about.html
@@ -57,7 +57,7 @@
                 In 2014, the Department of Records and Information Services and the Department of Information Technology
                 and Telecommunications began working with the open source code from the Oakland application to create
                 additional features and functionality required to meet the FOIL needs of New York City agencies. The
-                resulting FOIL portal, is part of Mayor de Blasio's overall initiative for transparency in government. The
+                resulting FOIL portal is part of Mayor de Blasio's overall initiative for transparency in government. The
                 initial beta version of OpenRecords was released in March 2015 for use with eight pilot agencies. The
                 current version 2.1 was released in August 2017 and is used by 38 agencies, with more to be added on a
                 regular basis. The DORIS development team rewrote all of the code to increase the stability and

--- a/app/templates/main/about.html
+++ b/app/templates/main/about.html
@@ -57,9 +57,9 @@
                 In 2014, the Department of Records and Information Services and the Department of Information Technology
                 and Telecommunications began working with the open source code from the Oakland application to create
                 additional features and functionality required to meet the FOIL needs of New York City agencies. The
-                resulting FOIL portal, is part of the Mayor’s overall initiative for transparency in government. The
-                initial beta version of OpenRecords was released in March 2015 for use with eight pilot agencies.. The
-                current version 2.0 was released in January 2017 and is used by 21 agencies, with more to be added on a
+                resulting FOIL portal, is part of Mayor de Blasio's overall initiative for transparency in government. The
+                initial beta version of OpenRecords was released in March 2015 for use with eight pilot agencies. The
+                current version 2.1 was released in August 2017 and is used by 38 agencies, with more to be added on a
                 regular basis. The DORIS development team rewrote all of the code to increase the stability and
                 robustness of the application.
 

--- a/app/templates/main/about.html
+++ b/app/templates/main/about.html
@@ -43,8 +43,7 @@
                 interfere with investigations or judicial proceedings, deprive a person to a fair trial, identify a
                 confidential source, reveal investigative techniques, or endanger a person's life. Records
                 such as reports and data will be posted to the portal 20 business days after they are sent
-                directly to the requester. Records that contain email correspondence from government employees
-                will be sent directly to the requester.
+                directly to the requester.
             </p>
             <hr>
             <h4 id="why">

--- a/app/templates/main/faq.html
+++ b/app/templates/main/faq.html
@@ -135,8 +135,7 @@
         <p>You may appeal a decision to deny your request within 30 days of receiving the denial or partial
             denial. The denial or partial denial should provide the contact information for the Agency Appeals
             Officer. Your appeal letter should state the reason you are appealing and why the agency's response
-            to the request was improper. [See the New York State <a
-                    href="http://www.dos.ny.gov/coog/Right_to_know.html#appealsample">sample FOIL appeal</a>]
+            to the request was improper.
             <br/>
             <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
         <br>

--- a/app/templates/main/faq.html
+++ b/app/templates/main/faq.html
@@ -47,7 +47,7 @@
             people. If disclosure of a record would be damaging to an individual or prevent a government agency
             from carrying out its duties, it is likely that some or all of the record may be withheld. You can
             read the law, including the exceptions, by clicking here. <a
-                    href="http://www.dos.ny.gov/coog/Right_to_know.html#foil">See FOIL &sect;87(2)</a>
+                    href="https://law.justia.com/codes/new-york/2015/pbo/article-6/87/">See FOIL &sect;87(2)</a>
             <br/>
             <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
         <br>

--- a/app/templates/request/events/row.html
+++ b/app/templates/request/events/row.html
@@ -5,7 +5,7 @@
             {{ row_num }}
         </div>
         <div class="col-sm-9 text-right">
-            {{ moment(event.timestamp).format('D/M/YY h:mm A') }}
+            {{ moment(event.timestamp).format('MM/DD/YYYY h:mm A') }}
         </div>
     </div>
     <div class="row history-row-content">

--- a/app/templates/request/responses/modal_body/determinations.html
+++ b/app/templates/request/responses/modal_body/determinations.html
@@ -1,10 +1,10 @@
 {% if response.dtype in (determination_type.ACKNOWLEDGMENT, determination_type.REOPENING) %}
-    <p>Expected date of completion: <strong>{{ moment(response.date).format('dddd, MMMM D, YYYY [at] h:mm A')}}</strong></p>
+    <p>Expected date of completion: <strong>{{ moment(response.date).format('dddd, MM/DD/YYYY [at] h:mm A')}}</strong></p>
     {% if response.reason is not none %}
         <p>{{ response.reason }}</p>
     {% endif %}
 {% elif response.dtype == determination_type.EXTENSION %}
-    <p>Due date changed to: <strong>{{ moment(response.date).format('dddd, MMMM D, YYYY [at] h:mm A') }}</strong></p>
+    <p>Due date changed to: <strong>{{ moment(response.date).format('dddd, MM/DD/YYYY [at] h:mm A') }}</strong></p>
     {% if response.reason is not none %}
         <p>{{ response.reason }}</p>
     {% endif %}

--- a/app/templates/request/responses/row.html
+++ b/app/templates/request/responses/row.html
@@ -9,7 +9,7 @@
 
     {% if current_user.is_agency %}
         <div class="col-md-6 text-right">
-            {{ moment(response.date_modified).format('dddd, MMMM D, YYYY [at] h:mm A') }}
+            {{ moment(response.date_modified).format('dddd, MM/DD/YYYY [at] h:mm A') }}
         </div>
         <div class="row">
             <div class="col-md-10 metadata-preview">
@@ -25,7 +25,7 @@
             {% endif %}
         </div>
         <div class="col-md-3">
-            {{ moment(response.date_modified).format('dddd, MMMM D, YYYY [at] h:mm A') }}
+            {{ moment(response.date_modified).format('dddd, MM/DD/YYYY [at] h:mm A') }}
         </div>
     {% endif %}
 </div>

--- a/app/templates/request/result_row.html
+++ b/app/templates/request/result_row.html
@@ -24,7 +24,7 @@
                 {{ request._id }}
             </div>
             <div class="col-sm-2">
-                {{ moment(request._source.date_received).format('MMM DD, YYYY') }}
+                {{ moment(request._source.date_received).format('MM/DD/YYYY') }}
             </div>
             <div class="col-sm-{% if current_user.is_agency %}1{% else %}3{% endif %}">
                 {% if current_user.is_agency %}
@@ -43,11 +43,11 @@
                 </div>
             {% endif %}
             <div class="col-sm-2">
-                {{ moment(request._source.date_due).format('MMM DD, YYYY') }}
+                {{ moment(request._source.date_due).format('MM/DD/YYYY') }}
             </div>
             {% if current_user.is_agency %}
                 <div class="col-sm-2">
-                    {{ moment(request._source.date_closed).format('MMM DD, YYYY') if request._source.date_closed else '' }}
+                    {{ moment(request._source.date_closed).format('MM/DD/YYYY') if request._source.date_closed else '' }}
                 </div>
                 <div class="col-sm-2">
                     {{ request._source.requester_name }}


### PR DESCRIPTION
All dates in the portal now use the MM/DD/YYYY format with the exception of dates in determination emails in order to look more formal (Ex. Monday, February 12, 2018) 

This PR also includes text changes for:
- OS-413
- OS-414
- OS-417
- OS-418