### PR TITLE
Feature/OP-1361: QA fix for multiple re upload attempts

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1392,12 +1392,13 @@ class Files(Responses):
                  date_modified=None,
                  is_editable=False):
         try:
-            file_exists = Files.query.filter_by(request_id=request_id, hash=hash_).one_or_none()
-            if file_exists is not None and not file_exists.deleted:
-                raise DuplicateFileException(
-                    file_name=name,
-                    request_id=request_id
-                )
+            file_exists = Files.query.filter_by(request_id=request_id, hash=hash_).all()
+            for file in file_exists:
+                if not file.deleted:
+                    raise DuplicateFileException(
+                        file_name=name,
+                        request_id=request_id
+                    )
         except MultipleResultsFound:
             raise DuplicateFileException(
                 file_name=name,


### PR DESCRIPTION
Fixing a bug found by QA where a user can't upload the same file after deleting it 2 times. This is caused by the original query `file_exists = Files.query.filter_by(request_id=request_id, hash=hash_).one_or_none()` that doesn't produce a list of all the times a file is re uploaded. Modified the query to produce a list and then loop through each file to make sure it has been deleted or else raise a DuplicateFileException.