### PR TITLE
Bugfix/OP-1389: Add Button Not Working in Agency Administration

### DIFF
--- a/app/templates/admin/main.html
+++ b/app/templates/admin/main.html
@@ -36,6 +36,7 @@
             <hr>
         {% endif %}
         {% if user_form.users.choices %}
+            <input type="hidden" name="agency-ein" value="{{ agency_ein }}">
             <div class="row">
                 {{ user_form.users.label }}
                 <div class="row">


### PR DESCRIPTION
This PR fixes the bug found during the last 2 maintenances where the add button was not working in the agency administration page. When activating agency users in the agency administration page, if there are currently no active users the add button will not work because it can't find the agency ein of the user.

Fix: Add a hidden field to the user list section that contains the agency ein.