### PR TITLE
Feature/OP-1383: Alert if the requester has no email address

### DIFF
--- a/app/static/styles/view_request.css
+++ b/app/static/styles/view_request.css
@@ -71,3 +71,7 @@
 #agency-contact-modal-text .MainNavText {
     font-size: 16px;
 }
+
+.no-email-alert {
+    margin-bottom: 0px;
+}

--- a/app/templates/request/_view_request_info.html
+++ b/app/templates/request/_view_request_info.html
@@ -90,8 +90,8 @@
                     {% endif %}
                 </div>
             </div>
-            <br>
-            {% if current_user.is_agency %}
+            {% if current_user in request.agency_users %}
+                <br>
                 <div class="row">
                     <div class="request-label lead">This requester can be contacted by:</div>
                     <div class="lead">

--- a/app/templates/request/_view_request_info.html
+++ b/app/templates/request/_view_request_info.html
@@ -90,6 +90,26 @@
                     {% endif %}
                 </div>
             </div>
+            <br>
+            {% if current_user.is_agency %}
+                <div class="row">
+                    <div class="request-label lead">This requester can be contacted by:</div>
+                    <div class="lead">
+                        {% if request.requester.email %}
+                            Email<br>
+                        {% endif %}
+                        {% if request.requester.phone_number %}
+                            Phone number<br>
+                        {% endif %}
+                        {% if request.requester.fax_number %}
+                            Fax number<br>
+                        {% endif %}
+                        {% if request.requester.mailing_address['address_one'] and request.requester.mailing_address['city'] %}
+                            Mail
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/app/templates/request/view_request.html
+++ b/app/templates/request/view_request.html
@@ -36,6 +36,13 @@
 
             <!-- Action Button Column for Agency Users -->
             {% if current_user in request.agency_users %}
+                {% if not request.requester.email %}
+                    <div class="alert alert-danger col-md-12 no-email-alert" role="alert">
+                        <strong>Please be advised, this requester has not provided an email address and will
+                            not receive notifications regarding this request. Please use an alternate form of contact
+                            provided by the requester.</strong>
+                    </div>
+                {% endif %}
                 <div class="col-md-12"><h3>Actions</h3>
                     <div class="tabbable tabs-left" id="mobile-toggle">
                         <ul class="nav nav-tabs">


### PR DESCRIPTION
This PR adds a section showing what forms of contact the requester provided to the view request page (only viewable by agency users) as well as an alert if no email has been provided.