### PR TITLE
Bugfix/OP-1339: Fix denial/closing dates for MMR metrics

### DIFF
--- a/app/lib/date_utils.py
+++ b/app/lib/date_utils.py
@@ -3,6 +3,7 @@ from business_calendar import FOLLOWING
 from app import calendar
 from app.lib import NYCHolidays
 from flask import current_app
+from datetime import datetime
 
 DEFAULT_YEARS_HOLIDAY_LIST = 5
 
@@ -15,6 +16,17 @@ def get_following_date(date_created):
     :return: date submitted (local) which is the date_created rounded off to the next business day
     """
     return calendar.addbusdays(date_created, FOLLOWING)
+
+
+def get_next_business_day():
+    """
+    Generates the next business day based on the current date
+    :return: datetime object with the next business day set to 13:00 PM UTC (09:00 AM EST)
+    """
+    next_business_day = get_following_date(datetime.utcnow())
+    next_business_day = next_business_day.replace(hour=13, minute=00, second=00, microsecond=00)
+
+    return next_business_day
 
 
 def get_due_date(date_submitted, days_until_due, tz_name):

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -48,7 +48,7 @@ from app.constants import (
     TINYMCE_EDITABLE_P_TAG
 )
 from app.lib.date_utils import (
-    get_following_date,
+    get_next_business_day,
     get_due_date,
     process_due_date,
     get_release_date,
@@ -226,15 +226,12 @@ def add_denial(request_id, reason_ids, email_content):
         if not calendar.isbusday(datetime.utcnow()) or datetime.utcnow().date() < request.date_submitted.date():
             # push the denial date to the next business day if it is a weekend/holiday
             # or if it is before the date submitted
-            next_business_day = get_following_date(datetime.utcnow())
-            next_business_day = next_business_day.replace(hour=9, minute=00, second=00, microsecond=00)
-            next_business_day = local_to_utc(next_business_day, current_app.config['APP_TIMEZONE'])
             response = Determinations(
                 request_id,
                 RELEASE_AND_PUBLIC,
                 determination_type.DENIAL,
                 format_determination_reasons(reason_ids),
-                date_modified=next_business_day
+                date_modified=get_next_business_day()
             )
         else:
             response = Determinations(
@@ -313,15 +310,12 @@ def add_closing(request_id, reason_ids, email_content):
         if not calendar.isbusday(datetime.utcnow()) or datetime.utcnow().date() < current_request.date_submitted.date():
             # push the closing date to the next business day if it is a weekend/holiday
             # or if it is before the date submitted
-            next_business_day = get_following_date(datetime.utcnow())
-            next_business_day = next_business_day.replace(hour=9, minute=00, second=00, microsecond=00)
-            next_business_day = local_to_utc(next_business_day, current_app.config['APP_TIMEZONE'])
             response = Determinations(
                 request_id,
                 RELEASE_AND_PUBLIC,
                 determination_type.CLOSING,
                 format_determination_reasons(reason_ids),
-                date_modified=next_business_day
+                date_modified=get_next_business_day()
             )
         else:
             response = Determinations(

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -48,6 +48,7 @@ from app.constants import (
     TINYMCE_EDITABLE_P_TAG
 )
 from app.lib.date_utils import (
+    get_following_date,
     get_due_date,
     process_due_date,
     get_release_date,
@@ -222,12 +223,26 @@ def add_denial(request_id, reason_ids, email_content):
                 request_id,
                 es_update=False
             )
-        response = Determinations(
-            request_id,
-            RELEASE_AND_PUBLIC,
-            determination_type.DENIAL,
-            format_determination_reasons(reason_ids)
-        )
+        if not calendar.isbusday(datetime.utcnow()) or datetime.utcnow().date() < request.date_submitted.date():
+            # push the denial date to the next business day if it is a weekend/holiday
+            # or if it is before the date submitted
+            next_business_day = get_following_date(datetime.utcnow())
+            next_business_day = next_business_day.replace(hour=9, minute=00, second=00, microsecond=00)
+            next_business_day = local_to_utc(next_business_day, current_app.config['APP_TIMEZONE'])
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.DENIAL,
+                format_determination_reasons(reason_ids),
+                date_modified=next_business_day
+            )
+        else:
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.DENIAL,
+                format_determination_reasons(reason_ids)
+            )
         create_object(response)
         create_response_event(event_type.REQ_CLOSED, response)
         request.es_update()
@@ -295,12 +310,26 @@ def add_closing(request_id, reason_ids, email_content):
                 request_id,
                 es_update=False
             )
-        response = Determinations(
-            request_id,
-            RELEASE_AND_PUBLIC,
-            determination_type.CLOSING,
-            format_determination_reasons(reason_ids)
-        )
+        if not calendar.isbusday(datetime.utcnow()) or datetime.utcnow().date() < current_request.date_submitted.date():
+            # push the closing date to the next business day if it is a weekend/holiday
+            # or if it is before the date submitted
+            next_business_day = get_following_date(datetime.utcnow())
+            next_business_day = next_business_day.replace(hour=9, minute=00, second=00, microsecond=00)
+            next_business_day = local_to_utc(next_business_day, current_app.config['APP_TIMEZONE'])
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.CLOSING,
+                format_determination_reasons(reason_ids),
+                date_modified=next_business_day
+            )
+        else:
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.CLOSING,
+                format_determination_reasons(reason_ids)
+            )
         create_object(response)
         create_response_event(event_type.REQ_CLOSED, response)
         current_request.es_update()

--- a/build_scripts/db_setup/backup.py
+++ b/build_scripts/db_setup/backup.py
@@ -1,6 +1,5 @@
 #!python
 
-import time
 from time import localtime, strftime
 import subprocess
 import os
@@ -24,11 +23,11 @@ email = """From: OpenRecords Backup Report <backup@records.nyc.go>
 To: OpenRecords Support Staff <openrecords@records.nyc.gov>
 Subject: OpenRecords Backup Report %s
 
-""" % time.strftime("%Y-%m-%d %H-%M-%S", time.localtime())
+""" % strftime("%Y-%m-%d %H-%M-%S", localtime())
 
 
 def log(string):
-    return str(time.strftime("%Y-%m-%d %H-%M-%S", time.localtime()) + ": " + str(string) + "\n")
+    return str(strftime("%Y-%m-%d %H-%M-%S", localtime()) + ": " + str(string) + "\n")
 
 
 # Change the value in brackets to keep more/fewer files. time.time() returns seconds since 1970...

--- a/build_scripts/db_setup/backup.py
+++ b/build_scripts/db_setup/backup.py
@@ -1,6 +1,7 @@
 #!python
 
 import time
+from time import localtime, strftime
 import subprocess
 import os
 import glob


### PR DESCRIPTION
This PR fixes problems found during MMR metrics. 2 main issues exists:

1) If an anonymous user submits a request the date submitted will be current date + 1 business day. So if an agency user denies/closes on the current date, the time difference between the date submitted and date denied/closed will be -1 which means you denied/closed a request before it was actually submitted

2) If an agency user denies/closes a request on a weekend/holiday those requests will not show up in the final report that is being generated.

Fix: If either of these situations occur, push the denial/closing date to 9:00 AM the following business day.

Concerns:
1) If you push the denial/closing date to the following business day you are effectively working in the future.
2) If you reopen a request that has its denial/closing pushed, then the reopen date modified will be before the denial/closing date modified. This causes it to appear out of order on the front end response rows.