### PR TITLE
Feature/OP-1388: Deactivate button for Super User

### DIFF
--- a/app/agency/utils.py
+++ b/app/agency/utils.py
@@ -72,7 +72,8 @@ def update_agency_active_status(agency_ein, is_active):
             active_users = get_agency_active_users(agency_ein)
             for user in active_users:
                 update_object(
-                    {"is_agency_active": "False"},
+                    {"is_agency_active": "False",
+                     "is_agency_admin": "False"},
                     AgencyUsers,
                     (user.guid, user.auth_user_type, agency_ein)
                 )
@@ -87,9 +88,9 @@ def update_agency_active_status(agency_ein, is_active):
                                         "ein": agency_ein,
                                         "is_active": "True"},
                         new_value={"user_guid": user.guid,
-                                        "auth_user_type": user.auth_user_type,
-                                        "ein": agency_ein,
-                                        "is_active": "False"},
+                                   "auth_user_type": user.auth_user_type,
+                                   "ein": agency_ein,
+                                   "is_active": "False"},
                         timestamp=datetime.utcnow()
                     )
                 )

--- a/app/models.py
+++ b/app/models.py
@@ -912,6 +912,14 @@ class Requests(db.Model):
             }
         )
 
+    def es_delete(self):
+        """ Delete a document from the elastic search index """
+        es.delete(
+            index=current_app.config["ELASTICSEARCH_INDEX"],
+            doc_type='request',
+            id=self.id
+        )
+
     def __repr__(self):
         return '<Requests %r>' % self.id
 

--- a/app/static/js/admin/main.js
+++ b/app/static/js/admin/main.js
@@ -20,6 +20,20 @@ $(function () {
             }
         });
     });
+    // DEACTIVATE AGENCY
+    $("#deactivate").click(function () {
+        var agencyEin = $("#agencies").val();
+        $.ajax({
+            url: "/agency/" + agencyEin,
+            type: "PATCH",
+            data: {
+                is_active: false
+            },
+            success: function () {
+                window.location = window.location.origin + "/admin/" + agencyEin;
+            }
+        });
+    });
     // SET SUPER USER
     $("input[name^='user-super']").click(function () {
         var row = $(this).parents(".row");

--- a/app/templates/admin/main.html
+++ b/app/templates/admin/main.html
@@ -30,6 +30,10 @@
                         <div class="col-sm-4">
                             <button type="button" class="btn btn-sm btn-primary" id="activate">Activate</button>
                         </div>
+                    {% elif current_user.is_super and agency_is_active %}
+                        <div class="col-sm-4">
+                            <button type="button" class="btn btn-sm btn-primary" id="deactivate">Deactivate</button>
+                        </div>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
This PR adds a Deactivate button to the Agency Administration page when you are a super user. Deactivating an agency will:

- Remove that agency's requests from the elastic search index
- Toggle that agency's is_active column to False
- Prevent login for users in that agency by toggling their is_agency_active column to False
- Add entries in the Events table for agency_deactivated and agency_user_deactivated

**Note:**
For multi-agency users you have to make sure you switch their primary agency to an active agency before you deactivate an agency they are part of or else you will get an error on the Manage Account page.