### PR TITLE
Bugfix/OP-1396: Previous Due Date is not stored in the Events table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1570,7 +1570,7 @@ class Determinations(Responses):
         if self.dtype in (determination_type.ACKNOWLEDGMENT,
                           determination_type.EXTENSION,
                           determination_type.REOPENING):
-            val['date'] = self.date.isoformat()
+            val['due_date'] = self.date.isoformat()
         return val
 
 

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -326,8 +326,10 @@ def add_reopening(request_id, date, tz_name, email_content):
     :param email_content: email body associated with the reopened request
 
     """
-    if Requests.query.filter_by(id=request_id).one().status == request_status.CLOSED:
+    request = Requests.query.filter_by(id=request_id).one()
+    if request.status == request_status.CLOSED:
         date = datetime.strptime(date, '%Y-%m-%d')
+        previous_due_date = {"due_date": request.due_date.isoformat()}
         new_due_date = process_due_date(local_to_utc(date, tz_name))
         privacy = RELEASE_AND_PUBLIC
         response = Determinations(
@@ -338,7 +340,7 @@ def add_reopening(request_id, date, tz_name, email_content):
             new_due_date
         )
         create_object(response)
-        create_response_event(event_type.REQ_REOPENED, response)
+        create_response_event(event_type.REQ_REOPENED, response, previous_value=previous_due_date)
         update_object(
             {'status': request_status.IN_PROGRESS,
              'due_date': new_due_date,


### PR DESCRIPTION
This PR adds the previous due_date to events for acknowledgments, extensions, and reopening. Also changed 'date' to 'due_date' in val_for_events() for the Determinations class to better reflect what values were changed.