### PR TITLE
Bugfix/OP-1415: Pressing Enter multiple times creates multiple requests

### DIFF
--- a/app/request/forms.py
+++ b/app/request/forms.py
@@ -154,7 +154,7 @@ class AnonymousRequestForm(Form):
     # Request Information
     request_category = SelectField('Category (optional)', choices=CATEGORIES)
     request_agency = SelectField('Agency (required)', choices=None)
-    request_title = TextAreaField('Request Title (required)')
+    request_title = StringField('Request Title (required)')
     request_description = TextAreaField('Request Description (required)')
 
     # Personal Information

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -249,6 +249,10 @@ $(document).ready(function () {
 
     // Disable submit button on form submission
     $('#request-form').submit(function () {
+        // Prevent multiple submissions
+        $(this).submit(function() {
+            return false;
+        });
         $('#submit').hide();
         $('#processing-submission').show()
     });

--- a/app/static/js/request/new-request-anon.js
+++ b/app/static/js/request/new-request-anon.js
@@ -263,6 +263,10 @@ $(document).ready(function () {
 
     // Disable submit button on form submission
     $('#request-form').submit(function () {
+        // Prevent multiple submissions
+        $(this).submit(function() {
+            return false;
+        });
         $('#submit').hide();
         $('#processing-submission').show()
     });

--- a/app/static/js/request/new-request-user.js
+++ b/app/static/js/request/new-request-user.js
@@ -155,6 +155,10 @@ $(document).ready(function () {
 
     // Disable submit button on form submission
     $('#request-form').submit(function () {
+        // Prevent multiple submissions
+        $(this).submit(function() {
+            return false;
+        });
         $('#submit').hide();
         $('#processing-submission').show()
     });

--- a/app/templates/request/new_request_agency.html
+++ b/app/templates/request/new_request_agency.html
@@ -136,12 +136,12 @@
                 {# User of title #}
                 {{ form.user_title.label(class="request-heading") }}
                 {{ form.user_title(id="user-title", class="input-block-level",
-                placeholder="Your role in your organization (if applicable)", maxlength=64) }}
+                placeholder="Your role in your organization (if applicable)", maxlength="64") }}
                 <h5 id="user-title-character-count">64 characters remaining</h5><br>
                 {# Organization/Agency user belongs to #}
                 {{ form.user_organization.label(class="request-heading") }}
                 {{ form.user_organization(id="user-organization", class="input-block-level",
-                placeholder="Your organization (if applicable)", maxlength=128) }}
+                placeholder="Your organization (if applicable)", maxlength="128") }}
                 <h5 id="organization-character-count">128 characters remaining</h5><br>
                 {# Phone number of user #}
                 {{ form.phone.label(class="request-heading") }}

--- a/app/templates/request/new_request_agency.html
+++ b/app/templates/request/new_request_agency.html
@@ -23,12 +23,12 @@
                     respond to your request.</p>
                 {# Agency request belongs to #}
                 {% if current_user.agencies.all()|length > 1 %}
-                    {{ form.request_agency.label(class='request-heading agency-label') }}
+                    {{ form.request_agency.label(class="request-heading agency-label") }}
                     <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Agency Field"
                           data-content="List of agencies you can submit a request to on behalf of a requester."
                           class="glyphicon glyphicon-question-sign">
                     </span>
-                    {{ form.request_agency(id='request-agency', class='input-block-level') }}<br>
+                    {{ form.request_agency(id="request-agency", class="input-block-level") }}<br>
                 {% else %}
                     <input type="hidden" id="request-agency" value="{{ current_user.default_agency_ein }}" />
                 {% endif %}
@@ -38,13 +38,13 @@
                 </div>
 
                 {# Title of the request #}
-                {{ form.request_title.label(class='request-heading title-label') }}
+                {{ form.request_title.label(class="request-heading title-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Title Field"
                       data-content="Enter a brief title for your request, title will be made public and limited to 90 characters."
                       class="glyphicon glyphicon-question-sign">
                 </span>
-                {{ form.request_title(id='request-title', class='input-block-level',
-                        placeholder='Please provide a short summary of your request.', maxlength="90") }}
+                {{ form.request_title(id="request-title", class="input-block-level",
+                        placeholder="Please provide a short summary of your request.", maxlength="90") }}
                 <h5 id="title-character-count">90 characters remaining</h5>
                 <div class="alert alert-info">
                     <p><strong>
@@ -53,12 +53,12 @@
                     </strong></p>
                 </div>
                 {# Description of the request #}
-                {{ form.request_description.label(class='request-heading description-label') }}
+                {{ form.request_description.label(class="request-heading description-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Description Field"
                       data-content="Enter a detailed description of the request."
                       class="glyphicon glyphicon-question-sign">
                 </span>
-                {{ form.request_description(id='request-description', class='input-block-level',
+                {{ form.request_description(id="request-description", class="input-block-level",
                     placeholder="Provide more information about your request to help the City locate the record. If you don't know the record name, describe the type of information you think it would contain and the approximate date range. Do not include private information such as a social security # or credit card.",
                         maxlength="5000") }}
                 <h5 id="description-character-count">5000 characters remaining</h5>
@@ -69,12 +69,12 @@
 
                 {# Upload field for user to add files #}
                 <div id="upload-control" class="col-sm-12">
-                    {{ form.request_file.label(class='request-heading') }}
+                    {{ form.request_file.label(class="request-heading") }}
                     &nbsp;<span class="request-heading">(Must be less than 20 Mb)</span>
                     <br>
                     <div class="alert alert-danger file-error" hidden></div>
                     <label class="btn btn-info">Choose File
-                        {{ form.request_file(id='request-file', style="display:none") }}
+                        {{ form.request_file(id="request-file", style="display:none") }}
                     </label>
                     <button type="button" id="clear-file" class="btn btn-danger pull-right">Clear File</button>
                     <div id="filename"></div>
@@ -93,10 +93,10 @@
                 <div class="format-label">
                     Format Received (required)
                 </div>
-                {{ form.method_received(id='method-received', class='input-block-level') }}
+                {{ form.method_received(id="method-received", class="input-block-level") }}
                 {# Date request was received #}
                 Request Date (required)
-                {{ form.request_date(id='request-date', class='input-block-level dtpick') }}
+                {{ form.request_date(id="request-date", class="input-block-level dtpick") }}
 
                 <h1>Personal Information
                     <small data-toggle="popover" data-placement="right" data-trigger="hover"
@@ -109,17 +109,17 @@
                 <p>This information will not be publicly viewable on this site. You must provide contact
                     information so that the agency can respond to your request for records.</p>
                 {# First name of user #}
-                {{ form.first_name.label(class='request-heading first-name-label') }}
-                {{ form.first_name(id='first-name', class='input-block-level', placeholder='John', maxlength=32) }}
+                {{ form.first_name.label(class="request-heading first-name-label") }}
+                {{ form.first_name(id="first-name", class="input-block-level", placeholder="John", maxlength="32") }}
                 <h5 id="first-name-character-count">32 characters remaining</h5><br>
                 {# Last name of user #}
-                {{ form.last_name.label(class='request-heading last-name-label') }}
-                {{ form.last_name(id='last-name', class='input-block-level', placeholder='Doe', maxlength=64) }}
+                {{ form.last_name.label(class="request-heading last-name-label") }}
+                {{ form.last_name(id="last-name", class="input-block-level", placeholder="Doe", maxlength="64") }}
                 <h5 id="last-name-character-count">64 characters remaining</h5><br>
                 {# Email of user #}
-                {{ form.email.label(class='request-heading email-label') }}
-                {{ form.email(id='email', class='input-block-level',
-                placeholder='requester@email.com', maxlength='254') }}<br>
+                {{ form.email.label(class="request-heading email-label") }}
+                {{ form.email(id="email", class="input-block-level",
+                placeholder="requester@email.com", maxlength="254") }}<br>
 
                 <div class="contact-form-error-message"></div>
                 <h1>Alternate Contact Information
@@ -134,48 +134,48 @@
                 <p>Note: You must have provide at least one type of contact information (phone number, fax number, or
                     address)</p>
                 {# User of title #}
-                {{ form.user_title.label(class='request-heading') }}
-                {{ form.user_title(id='user-title', class='input-block-level',
-                placeholder='Your role in your organization (if applicable)', maxlength=64) }}
+                {{ form.user_title.label(class="request-heading") }}
+                {{ form.user_title(id="user-title", class="input-block-level",
+                placeholder="Your role in your organization (if applicable)", maxlength=64) }}
                 <h5 id="user-title-character-count">64 characters remaining</h5><br>
                 {# Organization/Agency user belongs to #}
-                {{ form.user_organization.label(class='request-heading') }}
-                {{ form.user_organization(id='user-organization', class='input-block-level',
-                placeholder='Your organization (if applicable)', maxlength=128) }}
+                {{ form.user_organization.label(class="request-heading") }}
+                {{ form.user_organization(id="user-organization", class="input-block-level",
+                placeholder="Your organization (if applicable)", maxlength=128) }}
                 <h5 id="organization-character-count">128 characters remaining</h5><br>
                 {# Phone number of user #}
-                {{ form.phone.label(class='request-heading') }}
-                {{ form.phone(id='phone', class='input-block-level',
-                placeholder='(555) 555-5555') }}<br>
+                {{ form.phone.label(class="request-heading") }}
+                {{ form.phone(id="phone", class="input-block-level",
+                placeholder="(555) 555-5555") }}<br>
                 {# Fax number of user #}
-                {{ form.fax.label(class='request-heading') }}
-                {{ form.fax(id='fax', class='input-block-level',
-                placeholder='(555) 555-5555') }}<br>
+                {{ form.fax.label(class="request-heading") }}
+                {{ form.fax(id="fax", class="input-block-level",
+                placeholder="(555) 555-5555") }}<br>
                 {# Address of user #}
                 <div class="request-heading">Address</div>
                 Address Line 1
-                {{ form.address(id='address-line-1', class='input-block-level',
-                placeholder='123 Main Street') }}<br>
+                {{ form.address(id="address-line-1", class="input-block-level",
+                placeholder="123 Main Street") }}<br>
 
                 Address Line 2
-                {{ form.address_two(id='address_two', class='input-block-level',
-                placeholder='Apartment 3D') }}<br>
+                {{ form.address_two(id="address_two", class="input-block-level",
+                placeholder="Apartment 3D") }}<br>
                 <div class="col-sm-4 no-padding-left">
-                    {{ form.city.label(class='request-heading') }}
-                    {{ form.city(id='city', class='input-block-level',
-                    placeholder='New York') }}<br>
+                    {{ form.city.label(class="request-heading") }}
+                    {{ form.city(id="city", class="input-block-level",
+                    placeholder="New York") }}<br>
                 </div>
                 <div class="col-sm-4">
-                    {{ form.state.label(class='request-heading') }}
-                    {{ form.state(id='state', class='input-block-level') }}<br>
+                    {{ form.state.label(class="request-heading") }}
+                    {{ form.state(id="state", class="input-block-level") }}<br>
                 </div>
                 <div class="col-sm-4">
-                    {{ form.zipcode.label(class='request-heading', selected='New York') }}
-                    {{ form.zipcode(id='zipcode', class='input-block-level',
-                    placeholder='12345') }}<br>
+                    {{ form.zipcode.label(class="request-heading", selected="New York") }}
+                    {{ form.zipcode(id="zipcode", class="input-block-level",
+                    placeholder="12345") }}<br>
                 </div>
                 <input type="hidden" name="tz-name">
-                {{ form.submit(id='submit', class='btn-primary') }}
+                {{ form.submit(id="submit", class="btn-primary") }}
                 <span id="processing-submission" hidden>
                     <img src="{{ url_for("static", filename="img/loading.gif") }}"
                          alt="Processing" height="40" width="40">

--- a/app/templates/request/new_request_anon.html
+++ b/app/templates/request/new_request_anon.html
@@ -22,19 +22,19 @@
                     you about how much time is required to
                     respond to your request.</p>
                 {# Dropdown field Category for a Request #}
-                {{ form.request_category.label(class='request-heading') }}
+                {{ form.request_category.label(class="request-heading") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Category Field"
                       data-content="Selecting a category helps clarify which agency will receive the request by listing agencies grouped by categories."
                       class="glyphicon glyphicon-question-sign">
                 </span>
-                {{ form.request_category(id='request-category', class='input-block-level') }}<br>
+                {{ form.request_category(id="request-category", class="input-block-level") }}<br>
                 {# Field for the agency that the request will be submitted to #}
-                {{ form.request_agency.label(class='request-heading agency-label') }}
+                {{ form.request_agency.label(class="request-heading agency-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Agency Field"
                       data-content="List of all agencies available within OpenRecords that would handle your request."
                       class="glyphicon glyphicon-question-sign">
                 </span>
-                {{ form.request_agency(id='request-agency', class='input-block-level') }}<br>
+                {{ form.request_agency(id="request-agency", class="input-block-level") }}<br>
                 <div class="alert alert-info" id="request-agency-instructions" style="display: none;">
                     <div id="request-agency-instructions-content"></div>
                     <span id="request-agency-instructions-toggle">
@@ -45,7 +45,7 @@
                 </div>
 
                 {# Title of request #}
-                {{ form.request_title.label(class='request-heading title-label') }}
+                {{ form.request_title.label(class="request-heading title-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Title Field"
                       data-content="Enter a brief title for your request, title will be made public and limited to 90 characters."
                       class="glyphicon glyphicon-question-sign">
@@ -55,12 +55,12 @@
                     <p><b>Note: The agency, category, and title of your request will be visible to the public. Do not
                         enter personal information here.</b></p>
                 </div>
-                {{ form.request_title(id='request-title', class='input-block-level',
-                        placeholder='Please provide a short summary of your request.', maxlength="90") }}
+                {{ form.request_title(id="request-title", class="input-block-level",
+                        placeholder="Please provide a short summary of your request.", maxlength="90") }}
                 <h5 id="title-character-count">90 characters remaining</h5>
 
                 {# Description of Request #}
-                {{ form.request_description.label(class='request-heading description-label') }}
+                {{ form.request_description.label(class="request-heading description-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Description Field"
                       data-content="Enter a detailed description of the request."
                       class="glyphicon glyphicon-question-sign">
@@ -69,7 +69,7 @@
                     <p><b>Note: The request details you write here will not be visible to the public. However, the
                         agency may post a description of the records provided.</b></p>
                 </div>
-                {{ form.request_description(id='request-description', class='input-block-level',
+                {{ form.request_description(id="request-description", class="input-block-level",
                     placeholder="Provide more information about your request to help the City locate the record. If you don't know the record name, describe the type of information you think it would contain and the approximate date range. Do not include private information such as a social security # or credit card.",
                         maxlength="5000") }}
                 <h5 id="description-character-count">5000 characters remaining</h5>
@@ -77,12 +77,12 @@
 
                 {# Upload field for user to add files #}
                 <div id="upload-control" class="col-sm-12">
-                    {{ form.request_file.label(class='request-heading') }}
+                    {{ form.request_file.label(class="request-heading") }}
                     &nbsp;<span class="request-heading">(Must be less than 20 Mb)</span>
                     <br>
                     <div class="alert alert-danger file-error" hidden></div>
                     <label class="btn btn-info">Choose File
-                        {{ form.request_file(id='request-file', style="display:none") }}
+                        {{ form.request_file(id="request-file", style="display:none") }}
                     </label>
                     <button type="button" id="clear-file" class="btn btn-danger pull-right">Clear File</button>
                     <div id="filename"></div>
@@ -104,17 +104,17 @@
                 <p>This information will not be publicly viewable on this site. You must provide contact
                     information so that the agency can respond to your request for records.</p>
                 {# First name field #}
-                {{ form.first_name.label(class='request-heading first-name-label') }}
-                {{ form.first_name(id='first-name', class='input-block-level', placeholder='John', maxlength=32) }}
+                {{ form.first_name.label(class="request-heading first-name-label") }}
+                {{ form.first_name(id="first-name", class="input-block-level", placeholder="John", maxlength="32") }}
                 <h5 id="first-name-character-count">32 characters remaining</h5><br>
                 {# Last name field #}
-                {{ form.last_name.label(class='request-heading last-name-label') }}
-                {{ form.last_name(id='last-name', class='input-block-level', placeholder='Doe', maxlength=64) }}
+                {{ form.last_name.label(class="request-heading last-name-label") }}
+                {{ form.last_name(id="last-name", class="input-block-level", placeholder="Doe", maxlength="64") }}
                 <h5 id="last-name-character-count">64 characters remaining</h5><br>
                 {# Email field #}
-                {{ form.email.label(class='request-heading email-label') }}
-                {{ form.email(id='email', class='input-block-level',
-                placeholder='requester@email.com', maxlength='254') }}<br>
+                {{ form.email.label(class="request-heading email-label") }}
+                {{ form.email(id="email", class="input-block-level",
+                placeholder="requester@email.com", maxlength="254") }}<br>
 
                 <div class="contact-form-error-message"></div>
                 <h1>Alternate Contact Information
@@ -126,46 +126,46 @@
                 </h1>
                 <p>No information entered in this section will be visible to the public.</p>
                 {# Title of user #}
-                {{ form.user_title.label(class='request-heading') }}
-                {{ form.user_title(id='user-title', class='input-block-level',
-                placeholder='Your role in your organization (if applicable)', maxlength=64) }}
+                {{ form.user_title.label(class="request-heading") }}
+                {{ form.user_title(id="user-title", class="input-block-level",
+                placeholder="Your role in your organization (if applicable)", maxlength="64") }}
                 <h5 id="user-title-character-count">64 characters remaining</h5><br>
                 {# Organization user belongs to #}
-                {{ form.user_organization.label(class='request-heading') }}
-                {{ form.user_organization(id='user-organization', class='input-block-level',
-                placeholder='Your organization (if applicable)', maxlength=128) }}
+                {{ form.user_organization.label(class="request-heading") }}
+                {{ form.user_organization(id="user-organization", class="input-block-level",
+                placeholder="Your organization (if applicable)", maxlength="128") }}
                 <h5 id="organization-character-count">128 characters remaining</h5><br>
                 {# User's phone number #}
-                {{ form.phone.label(class='request-heading') }}
-                {{ form.phone(id='phone', class='input-block-level',
-                placeholder='(555) 555-5555') }}<br>
+                {{ form.phone.label(class="request-heading") }}
+                {{ form.phone(id="phone", class="input-block-level",
+                placeholder="(555) 555-5555") }}<br>
                 {# User's fax number #}
-                {{ form.fax.label(class='request-heading') }}
-                {{ form.fax(id='fax', class='input-block-level',
-                placeholder='(555) 555-5555') }}<br>
+                {{ form.fax.label(class="request-heading") }}
+                {{ form.fax(id="fax", class="input-block-level",
+                placeholder="(555) 555-5555") }}<br>
                 {# Address of user #}
                 <div class="request-heading">Address</div>
                 Address Line 1
-                {{ form.address(id='address-line-1', class='input-block-level',
-                placeholder='123 Main Street') }}<br>
+                {{ form.address(id="address-line-1", class="input-block-level",
+                placeholder="123 Main Street") }}<br>
 
                 Address Line 2
-                {{ form.address_two(id='address_two', class='input-block-level',
-                placeholder='Apartment 3D') }}<br>
+                {{ form.address_two(id="address_two", class="input-block-level",
+                placeholder="Apartment 3D") }}<br>
                 <div class="row-fluid">
                     <div class="col-sm-4 no-padding-left">
-                        {{ form.city.label(class='request-heading') }}
-                        {{ form.city(id='city', class='input-block-level',
-                        placeholder='New York') }}<br>
+                        {{ form.city.label(class="request-heading") }}
+                        {{ form.city(id="city", class="input-block-level",
+                        placeholder="New York") }}<br>
                     </div>
                     <div class="col-sm-4">
-                        {{ form.state.label(class='request-heading') }}
-                        {{ form.state(id='state', class='input-block-level') }}<br>
+                        {{ form.state.label(class="request-heading") }}
+                        {{ form.state(id="state", class="input-block-level") }}<br>
                     </div>
                     <div class="col-sm-4">
-                        {{ form.zipcode.label(class='request-heading', selected='New York') }}
-                        {{ form.zipcode(id='zipcode', class='input-block-level',
-                        placeholder='12345') }}<br>
+                        {{ form.zipcode.label(class="request-heading", selected="New York") }}
+                        {{ form.zipcode(id="zipcode", class="input-block-level",
+                        placeholder="12345") }}<br>
                     </div>
                 </div>
                 {#                <div class="col-sm-12 captcha">#}
@@ -175,7 +175,7 @@
                 {#                    <p>*Please Complete reCAPTCHA</p>#}
                 {#                </div>#}
                 <input type="hidden" name="tz-name">
-                {{ form.submit(id='submit', class='btn-primary') }}
+                {{ form.submit(id="submit", class="btn-primary") }}
                 <span id="processing-submission" hidden>
                     <img src="{{ url_for("static", filename="img/loading.gif") }}"
                          alt="Processing" height="40" width="40">

--- a/app/templates/request/new_request_user.html
+++ b/app/templates/request/new_request_user.html
@@ -21,19 +21,19 @@
                     you about how much time is required to
                     respond to your request.</p>
                 {# Category of requests #}
-                {{ form.request_category.label(class='request-heading') }}
+                {{ form.request_category.label(class="request-heading") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Category Field"
                       data-content="Selecting a category helps clarify which agency will receive the request by listing agencies grouped by categories."
                       class="glyphicon glyphicon-question-sign">
                 </span>
-                {{ form.request_category(id='request-category', class='input-block-level') }}<br>
+                {{ form.request_category(id="request-category", class="input-block-level") }}<br>
                 {# Agency request belongs to #}
-                {{ form.request_agency.label(class='request-heading agency-label') }}
+                {{ form.request_agency.label(class="request-heading agency-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Agency Field"
                       data-content="List of all agencies available within OpenRecords that would handle your request."
                       class="glyphicon glyphicon-question-sign">
                 </span>
-                {{ form.request_agency(id='request-agency', class='input-block-level') }}<br>
+                {{ form.request_agency(id="request-agency", class="input-block-level") }}<br>
                 <div class="alert alert-info" id="request-agency-instructions" style="display: none;">
                     <div id="request-agency-instructions-content"></div>
                     <span id="request-agency-instructions-toggle">
@@ -43,7 +43,7 @@
 
 
                 {# Title of the request #}
-                {{ form.request_title.label(class='request-heading title-label') }}
+                {{ form.request_title.label(class="request-heading title-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Title Field"
                       data-content="Enter a brief title for your request, title will be made public and limited to 90 characters."
                       class="glyphicon glyphicon-question-sign">
@@ -52,11 +52,11 @@
                     <p><b>Note: The agency, category, and title of your request will be visible to the public. Do not
                         enter personal information here.</b></p>
                 </div>
-                {{ form.request_title(id='request-title', class='input-block-level',
-                    placeholder='Please provide a short summary of your request.', maxlength="90") }}
+                {{ form.request_title(id="request-title", class="input-block-level",
+                    placeholder="Please provide a short summary of your request.", maxlength="90") }}
                 <h5 id="title-character-count">90 characters remaining</h5>
                 {# Description of the request #}
-                {{ form.request_description.label(class='request-heading description-label') }}
+                {{ form.request_description.label(class="request-heading description-label") }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Description Field"
                       data-content="Enter a detailed description of the request"
                       class="glyphicon glyphicon-question-sign">
@@ -65,19 +65,19 @@
                     <p><b>Note: The request details you write here will not be visible to the public. However, the
                         agency may post a description of the records provided.</b></p>
                 </div>
-                {{ form.request_description(id='request-description', class='input-block-level',
+                {{ form.request_description(id="request-description", class="input-block-level",
                     placeholder="Provide more information about your request to help the City locate the record. If you don't know the record name, describe the type of information you think it would contain and the approximate date range. Do not include private information such as a social security # or credit card.",
                         maxlength="5000") }}
                 <h5 id="description-character-count">5000 characters remaining</h5>
 
                 {# Upload field for user to add files #}
                 <div id="upload-control" class="col-sm-12">
-                    {{ form.request_file.label(class='request-heading') }}
+                    {{ form.request_file.label(class="request-heading") }}
                     &nbsp;<span class="request-heading">(Must be less than 20 Mb)</span>
                     <br>
                     <div class="alert alert-danger file-error" hidden></div>
                     <label class="btn btn-info">Choose File
-                        {{ form.request_file(id='request-file', style="display:none") }}
+                        {{ form.request_file(id="request-file", style="display:none") }}
                     </label>
                     <button type="button" id="clear-file" class="btn btn-danger pull-right">Clear File</button>
                     <div id="filename"></div>
@@ -89,7 +89,7 @@
                 </div>
                 <br><br>
                 <input type="hidden" name="tz-name">
-                {{ form.submit(id='submit', class='btn-primary') }}
+                {{ form.submit(id="submit", class="btn-primary") }}
                 <span id="processing-submission" hidden>
                     <img src="{{ url_for("static", filename="img/loading.gif") }}"
                          alt="Processing" height="40" width="40">
@@ -106,5 +106,6 @@
     <script type="text/javascript" src="{{ url_for('static', filename='js/plugins/jquery-ui.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/plugins/parsley.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static',filename='js/validation/custom_validators.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/request/main.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/request/new-request-user.js') }}"></script>
 {% endblock %}

--- a/app/templates/request/new_request_user.html
+++ b/app/templates/request/new_request_user.html
@@ -106,6 +106,5 @@
     <script type="text/javascript" src="{{ url_for('static', filename='js/plugins/jquery-ui.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/plugins/parsley.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static',filename='js/validation/custom_validators.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/request/main.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/request/new-request-user.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR fixes the bug to prevent multiple requests from being created if the enter button is pressed multiple times on the request page.

Notes:
- Title field in the request form for anonymous users has been changed from TextAreaField to StringField.
- Updated HTML tags in all request form html files to use double quotes instead of single quotes for consistency.