### PR TITLE
Bugfix/OP-1420: Add Title and Organization to Confirmation Email

### DIFF
--- a/app/templates/email_templates/email_confirmation.html
+++ b/app/templates/email_templates/email_confirmation.html
@@ -32,7 +32,35 @@
                                                 <strong>Name:</strong>
                                             </div>
                                             <div>
-                                                <span class="label">{{ user.first_name }} {{ user.last_name }}</span>
+                                                <span class="label">{{ user.name }}</span>
+                                            </div>
+                                        </div>
+                                        <div class="row-fluid">
+                                            <div>
+                                                <strong>Title:</strong>
+                                            </div>
+                                            <div>
+                                                {% if user.title %}
+                                                    <span class="label">
+                                                        {{ user.title }}
+                                                    </span>
+                                                {% else %}
+                                                    <span class="label">Not provided</span>
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                        <div class="row-fluid">
+                                            <div>
+                                                <strong>Organization:</strong>
+                                            </div>
+                                            <div>
+                                                {% if user.organization %}
+                                                    <span class="label">
+                                                        {{ user.organization }}
+                                                    </span>
+                                                {% else %}
+                                                    <span class="label">Not provided</span>
+                                                {% endif %}
                                             </div>
                                         </div>
                                         <div class="row-fluid">


### PR DESCRIPTION
Adds the requester title and organization to the confirmation email for a request, if provided. Otherwise shows "Not Provided"

Also updates the name to use the user.name property.