### PR TITLE
Bugfix/OP-1445: Reopening Not Working for Agencies with Letters Disabled

### DIFF
--- a/app/templates/response/add_reopening.html
+++ b/app/templates/response/add_reopening.html
@@ -24,7 +24,7 @@
                     </select>
                 </div>
                 {% else %}
-                <input type="hidden" name="method" value="email" />
+                    <input type="hidden" id="reopening-method" name="method" value="email" />
                 {% endif %}
                 <div id="reopening-letter-template-group" class="form-group" hidden>
                     <label for="reopening-letter-template">Template</label>


### PR DESCRIPTION
Agencies with generate letters disabled can't reopen request because the value of the reopening method is missing when the method is email. This is caused by a missing id to the method field in add_reopening.html.