### PR TITLE
Feature/OP-1447: Move Editable Blank space to before appeals

### DIFF
--- a/app/templates/email_templates/email_response_closing.html
+++ b/app/templates/email_templates/email_response_closing.html
@@ -4,13 +4,14 @@
         for the following reason{% if reasons|length > 1 %}s{% endif %}:
     </span>
     {{ reasons | safe }}
+    <span class="mceEditable editable-span"><br></span>
+    <span class="mceNonEditable editable-span"><br></span>
     <span class="mceNonEditable">
         You may appeal the decision to deny access to material that was redacted in part or withheld in entirety
         by contacting the agency's FOIL Appeals Officer: <a
             href="mailto:{{ agency_appeals_email }}">{{ agency_appeals_email }}</a>
         within 30 days.
     </span>
-    <p id="editable-p"><br></p>
 {% else %}
     {{ content | safe }}
     {% if denied %}

--- a/app/templates/email_templates/email_response_denial.html
+++ b/app/templates/email_templates/email_response_denial.html
@@ -4,6 +4,8 @@
         for the following reason{% if reasons|length > 1 %}s{% endif %}:
     </span>
     {{ reasons | safe }}
+    <span class="mceEditable editable-span"><br></span>
+    <span class="mceNonEditable editable-span"><br></span>
     <span class="mceNonEditable">
         Please visit <a href='{{ page }}'>{{ request.id }}</a> to view additional information and take any necessary
         action. You may appeal the decision to deny access to material that was redacted in part or withheld in entirety

--- a/app/templates/response/add_closing.js.html
+++ b/app/templates/response/add_closing.js.html
@@ -25,7 +25,7 @@
         var letter_info = second.find("#letter-template-id");
         var generate_letters_enabled = form.find("#generate-letters-enabled").val();
 
-        var edit_body_header = third.find('#edit-body-header');
+        var edit_body_header = third.find("#edit-body-header");
 
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {
@@ -150,6 +150,9 @@
                         fourth.find("input[name='summary']").val(data.template);
                         fourth.find(".confirmation-header").text(data.header);
                         fourth.find(".method").val(method.val());
+                        if ($(".editable-span").text() === "") {
+                            $(".editable-span").hide();
+                        }
                     }
                 });
             } else {

--- a/app/templates/response/add_denial.js.html
+++ b/app/templates/response/add_denial.js.html
@@ -150,6 +150,9 @@
                         fourth.find("input[name='summary']").val(data.template);
                         fourth.find(".confirmation-header").text(data.header);
                         fourth.find(".method").val(method.val());
+                        if ($(".editable-span").text() === "") {
+                            $(".editable-span").hide();
+                        }
                     }
                 });
             } else {


### PR DESCRIPTION
This PR adds an editable line above the appeals paragraph for denial and closing emails. If no text is entered then that line will be hidden on the confirmation step and final email.