### PR TITLE
Bugfix/OP-1339: Fix Date Closed Calculation

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1227,6 +1227,10 @@ class Responses(db.Model):
         return response_type.LETTER if response_type.LETTER in [cm.method_type for cm in
                                                                 communication_methods] else response_type.EMAIL
 
+    @property
+    def event_timestamp(self):
+        return Events.query.filter_by(response_id=self.id).one().timestamp
+
     def make_public(self):
         self.privacy = response_privacy.RELEASE_AND_PUBLIC
         self.release_date = calendar.addbusdays(datetime.utcnow(), RELEASE_PUBLIC_DAYS)

--- a/app/request/api/views.py
+++ b/app/request/api/views.py
@@ -210,13 +210,13 @@ def get_request_responses():
 
     current_request = Requests.query.filter_by(id=flask_request.args['request_id']).one()
 
-    responses = Responses.query.filter(
+    responses = Responses.query.join(Events, Responses.id == Events.response_id).filter(
         Responses.request_id == current_request.id,
         ~Responses.id.in_([cm.method_id for cm in CommunicationMethods.query.all()]),
         Responses.type != response_type.EMAIL,
         Responses.deleted == False
     ).order_by(
-        desc(Responses.date_modified)
+        desc(Events.timestamp)
     ).all()[start: start + RESPONSES_INCREMENT]
 
     template_path = 'request/responses/'

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -267,12 +267,23 @@ def add_denial(request_id, reason_ids, content, method, letter_template_id):
                 request_id,
                 es_update=False
             )
-        response = Determinations(
-            request_id,
-            RELEASE_AND_PUBLIC,
-            determination_type.DENIAL,
-            format_determination_reasons(reason_ids)
-        )
+        if not calendar.isbusday(datetime.utcnow()) or datetime.utcnow().date() < request.date_submitted.date():
+            # push the denial date to the next business day if it is a weekend/holiday
+            # or if it is before the date submitted
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.DENIAL,
+                format_determination_reasons(reason_ids),
+                date_modified=get_next_business_day()
+            )
+        else:
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.DENIAL,
+                format_determination_reasons(reason_ids)
+            )
         if method == 'letter':
             response.reason = 'A letter will be mailed to the requester.'
         create_object(response)
@@ -367,12 +378,23 @@ def add_closing(request_id, reason_ids, content, method, letter_template_id):
                 request_id,
                 es_update=False
             )
-        response = Determinations(
-            request_id,
-            RELEASE_AND_PUBLIC,
-            determination_type.CLOSING,
-            format_determination_reasons(reason_ids)
-        )
+        if not calendar.isbusday(datetime.utcnow()) or datetime.utcnow().date() < current_request.date_submitted.date():
+            # push the closing date to the next business day if it is a weekend/holiday
+            # or if it is before the date submitted
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.CLOSING,
+                format_determination_reasons(reason_ids),
+                date_modified=get_next_business_day()
+            )
+        else:
+            response = Determinations(
+                request_id,
+                RELEASE_AND_PUBLIC,
+                determination_type.CLOSING,
+                format_determination_reasons(reason_ids)
+            )
         if method == 'letter':
             response.reason = 'A letter will be mailed to the requester.'
         create_object(response)

--- a/app/templates/request/responses/row.html
+++ b/app/templates/request/responses/row.html
@@ -9,19 +9,19 @@
 
     {% if current_user.is_agency %}
         <div class="col-md-5 text-right">
-            {{ moment(response.date_modified).format('dddd, MM/DD/YYYY [at] h:mm A') }}
+            {{ moment(response.event_timestamp).format('dddd, MM/DD/YYYY [at] h:mm A') }}<br>
         </div>
         <div class="row">
             <div class="col-md-10 metadata-preview">
                 {% if show_preview and response.preview is not none %}
-                    {{ response.preview | safe}}
+                    {{ response.preview | safe }}
                 {% endif %}
             </div>
         </div>
     {% else %}
         <div class="col-md-6 metadata-preview">
             {% if show_preview and response.preview is not none %}
-                {{ response.preview | safe}}
+                {{ response.preview | safe }}
             {% endif %}
         </div>
         <div class="col-md-3">

--- a/app/templates/request/responses/row.html
+++ b/app/templates/request/responses/row.html
@@ -9,7 +9,7 @@
 
     {% if current_user.is_agency %}
         <div class="col-md-5 text-right">
-            {{ moment(response.event_timestamp).format('dddd, MM/DD/YYYY [at] h:mm A') }}<br>
+            {{ moment(response.event_timestamp).format('dddd, MM/DD/YYYY [at] h:mm A') }}
         </div>
         <div class="row">
             <div class="col-md-10 metadata-preview">


### PR DESCRIPTION
This PR adds back in the new pushed closing date calculation that was reverted in commit 5798aeb528b6713f18dc43f1bd5168d40fa0a9bf. Additionally it displays the response rows ordered by their corresponding Event timestamp. This fixes the problem where if the closing date gets pushed and you reopen the request, the the response rows appear out of order.

To test this:
- Force your computer's clock to be Saturday/Sunday
- Create a request as an agency user
- Deny/close that request
- Reopen that request

The response rows should have the reopening as the first row followed by the denial/closing. In the database the date_modified on the denial/closing Response should be the following Monday 9:00 AM (EST).