### PR TITLE
Bugfix/OP-1455: Unable to Generate Envelopes

### DIFF
--- a/app/lib/pdf.py
+++ b/app/lib/pdf.py
@@ -105,3 +105,22 @@ def generate_envelope_pdf(document):
     compiler = LatexCompiler()
 
     return compiler.compile(document)
+
+
+def escape_latex_characters(line):
+    """
+    Replace a string with the escaped LaTeX version of reserved characters
+    :param line: a string to be used in a LaTeX template
+    :return: a string with the escaped LaTeX version of reserved characters
+    """
+    line = line.replace('\\', '\\textbackslash')
+    line = line.replace('&', '\&')
+    line = line.replace('%', '\%')
+    line = line.replace('$', '\$')
+    line = line.replace('#', '\#')
+    line = line.replace('_', '\_')
+    line = line.replace('{', '\{')
+    line = line.replace('}', '\}')
+    line = line.replace('~', '\\textasciitilde')
+    line = line.replace('^', '\\textasciicircum')
+    return line

--- a/app/lib/pdf.py
+++ b/app/lib/pdf.py
@@ -30,10 +30,13 @@ class LatexCompiler:
         temp_tex = temp_file + '.tex'
         with open(temp_tex, 'wb') as f:
             f.write(document.encode('utf-8'))
-        proc = subprocess.Popen([*self.LATEX_COMMAND.split(' '), temp_tex], cwd=self._OUT_DIR)
+        proc = subprocess.Popen([*self.LATEX_COMMAND.split(' '), temp_tex], cwd=self._OUT_DIR, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
         return_code = proc.wait()
+        out, err = proc.communicate()
         if return_code != 0:
-            raise PDFCreationException(return_code)  # TODO: Make this a proper error
+            raise PDFCreationException(status_code=return_code, stdout=out, stderr=err)  # TODO: Make this a proper error
+
 
         data = None
         with open('{filename}.{extension}'.format(filename=temp_file, extension=self.FILE_EXTENSION), 'rb') as f:

--- a/app/lib/utils.py
+++ b/app/lib/utils.py
@@ -59,14 +59,16 @@ class DuplicateFileException(Exception):
 
 
 class PDFCreationException(Exception):
-    def __init__(self, pisa_status):
+    def __init__(self, status_code, stdout=b'', stderr=b''):
         """
         Exception used when xhtml2pdf fails to create a PDF.
-
-        :param pisa_status: Status / Error message from xhtml2pdf (pisa)
+        :param status_code: Process exit status code
+        :param stdout: STDOUT output
+        :param stderr: STDERR output
         """
         super(PDFCreationException, self).__init__(
-            "Failed to create PDF: \n{}".format(pisa_status)
+            "Failed to create PDF: \n\nStatus Code: {status_code}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}".format(
+                status_code=status_code, stdout=str(stdout, 'utf-8'), stderr=str(stderr, 'utf-8'))
         )
 
 

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -412,7 +412,6 @@ def response_instructions(request_id):
 def response_generate_envelope():
     """
     Create an Envelope for the Request.
-
     :return: redirect to view request page
     """
     envelope_data = EnvelopeDict()
@@ -420,14 +419,15 @@ def response_generate_envelope():
     template = flask_request.form.get('template')
     envelope_data['request_id'] = request_id
     envelope_data['recipient_name'] = str(flask_request.form.get('recipient_name')).upper()
-    envelope_data['organization'] = str(flask_request.form.get('organization')).upper()
+    envelope_data['organization'] = str(flask_request.form.get('organization')).upper().replace('&', '\&')
     envelope_data['organization'] = " ".join(
         ['\\seqsplit{{{}}}'.format(i) for i in envelope_data['organization'].split()])
-    envelope_data['street_address'] = '{} {}'.format(str(flask_request.form.get('address_one')).upper(),
-                                                     str(flask_request.form.get('address_two')).upper())
-    envelope_data['city'] = str(flask_request.form.get('city')).upper()
-    envelope_data['state'] = str(flask_request.form.get('state')).upper()
-    envelope_data['zipcode'] = str(flask_request.form.get('zipcode')).upper()
+    envelope_data['street_address'] = '{} {}'.format(
+        str(flask_request.form.get('address_one')).upper().replace('&', '\&'),
+        str(flask_request.form.get('address_two')).upper().replace('&', '\&'))
+    envelope_data['city'] = str(flask_request.form.get('city')).upper().replace('&', '\&')
+    envelope_data['state'] = str(flask_request.form.get('state')).upper().replace('&', '\&')
+    envelope_data['zipcode'] = str(flask_request.form.get('zipcode')).upper().replace('&', '\&')
 
     add_envelope(request_id, template, envelope_data)
 

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -38,7 +38,8 @@ from app.lib.permission_utils import (
 )
 from app.lib.pdf import (
     generate_pdf_flask_response,
-    generate_envelope_pdf
+    generate_envelope_pdf,
+    escape_latex_characters
 )
 from app.response import response
 from app.models import (
@@ -418,16 +419,16 @@ def response_generate_envelope():
     request_id = flask_request.form.get('request_id')
     template = flask_request.form.get('template')
     envelope_data['request_id'] = request_id
-    envelope_data['recipient_name'] = str(flask_request.form.get('recipient_name')).upper()
-    envelope_data['organization'] = str(flask_request.form.get('organization')).upper().replace('&', '\&')
+    envelope_data['recipient_name'] = escape_latex_characters(str(flask_request.form.get('recipient_name')).upper())
+    envelope_data['organization'] = escape_latex_characters(str(flask_request.form.get('organization')).upper())
     envelope_data['organization'] = " ".join(
         ['\\seqsplit{{{}}}'.format(i) for i in envelope_data['organization'].split()])
     envelope_data['street_address'] = '{} {}'.format(
-        str(flask_request.form.get('address_one')).upper().replace('&', '\&'),
-        str(flask_request.form.get('address_two')).upper().replace('&', '\&'))
-    envelope_data['city'] = str(flask_request.form.get('city')).upper().replace('&', '\&')
-    envelope_data['state'] = str(flask_request.form.get('state')).upper().replace('&', '\&')
-    envelope_data['zipcode'] = str(flask_request.form.get('zipcode')).upper().replace('&', '\&')
+        escape_latex_characters(str(flask_request.form.get('address_one')).upper()),
+        escape_latex_characters(str(flask_request.form.get('address_two')).upper()))
+    envelope_data['city'] = escape_latex_characters(str(flask_request.form.get('city')).upper())
+    envelope_data['state'] = escape_latex_characters(str(flask_request.form.get('state')).upper())
+    envelope_data['zipcode'] = escape_latex_characters(str(flask_request.form.get('zipcode')).upper())
 
     add_envelope(request_id, template, envelope_data)
 


### PR DESCRIPTION
This PR resolves an issue when generating envelopes on OpenRecords.

The issue is caused by the `&` character, which is used in LaTeX to represent a tab mark. 

To resolve this, all occurrences of the `&` character are escaped (`\&`).

Difficulties in troubleshooting this error were caused by inadequate information in the `PDFGenerationException` class. Two arguments have been added (`stderr`and `stdout`) to provide additional information for errors caused by os subprocess calls. 

*Original Bug Report*
Error occurs when trying to generate envelopes on some requests.

Error displayed in the following traceback from pdflatex:
```
\marginparwidth 90.0pt
\marginparsep   11.0pt
\columnsep  10.0pt
\skip\footins  10.0pt plus 2.0pt minus 4.0pt
\hoffset 0.0pt
\voffset 0.0pt
\mag 1000

(1in=72.27pt, 1cm=28.45pt)
-----------------------
! Misplaced alignment tab character &.
<argument> &

l.20 ...lit{&} \seqsplit{TEST,} \seqsplit{TEST}}
                                                  \par
I can't figure out why you would want to use a tab mark
here. If you just want an ampersand, the remedy is
simple: Just type `I\&' now. But if some right brace
up above has ended a previous alignment prematurely,
you're probably due for more error messages, and you
might try typing `S' now just to see what is salvageable.

[1

{/usr/share/texmf/fonts/map/pdftex/updmap/pdftex.map}] (./zz1qkabd.aux) )
Here is how much of TeX's memory you used:
 930 strings out of 256214
 11986 string characters out of 1917000
 63214 words of memory out of 1500000
 4263 multiletter control sequences out of 10000+200000
 3938 words of font info for 15 fonts, out of 1200000 for 2000
 645 hyphenation exceptions out of 8191
 25i,4n,30p,222b,104s stack positions out of 5000i,500n,6000p,200000b,15000s
</usr/
share/texmf/fonts/type1/bluesky/cm/cmr12.pfb>
Output written on zz1qkabd.pdf (1 page, 8538 bytes).
PDF statistics:
 10 PDF objects out of 1000 (max. 8388607)
 0 named destinations out of 1000 (max. 131072)
 1 words of extra memory for PDF output out of 10000 (max. 10000000)
```
