### PR TITLE
Hotfix/OP-1451: Unable to View My Requests After First Login

### DIFF
--- a/app/user/views.py
+++ b/app/user/views.py
@@ -89,8 +89,8 @@ def patch(user_id):
         same_agency = agency_ein in [agency.ein for agency in current_user.agencies.all()]
         associated_anonymous_requester = (user_.is_anonymous_requester
                                           and current_user.user_requests.filter_by(
-                                            request_id=user_.anonymous_request.id
-                                          ).first() is None)
+                    request_id=user_.anonymous_request.id
+                ).first() is None)
 
         is_agency_admin = request.form.get('is_agency_admin')
         is_agency_active = request.form.get('is_agency_active')
@@ -112,30 +112,30 @@ def patch(user_id):
         if ((updating_self and (
                 # super user attempting to change their own super status
                 (current_user.is_super and is_super is not None)
-            or
+                or
                 # agency admin or public user attempting to change their own agency/super status
                 (changing_status and (current_user_is_agency_admin or current_user.is_public)))) or
-           (not updating_self and (
-                # public user attempting to change another user
-                current_user.is_public
-            or
-                # agency user attempting to change a agency/super status
-                (current_user_is_agency_user and changing_status)
-            or
-                # agency user attempting to change a user that is not an anonymous requester
-                # for a request they are assigned to
-                (current_user_is_agency_user and (
-                            not user_.is_anonymous_requester or not associated_anonymous_requester))
-            or
-                # agency admin attempting to change another user that is not in the same agency or
-                # attempting to change more than just the agency status of a user
-                (current_user_is_agency_admin
-                 and not (associated_anonymous_requester or user_.is_anonymous_requester)
-                 and (not same_agency or changing_more_than_agency_status))
-            or
-                # agency admin attempting to change an anonymous requester for a request
-                # they are not assigned to
-                (current_user_is_agency_admin and associated_anonymous_requester)))):
+                (not updating_self and (
+                        # public user attempting to change another user
+                        current_user.is_public
+                        or
+                        # agency user attempting to change a agency/super status
+                        (current_user_is_agency_user and changing_status)
+                        or
+                        # agency user attempting to change a user that is not an anonymous requester
+                        # for a request they are assigned to
+                        (current_user_is_agency_user and (
+                                not user_.is_anonymous_requester or not associated_anonymous_requester))
+                        or
+                        # agency admin attempting to change another user that is not in the same agency or
+                        # attempting to change more than just the agency status of a user
+                        (current_user_is_agency_admin
+                         and not (associated_anonymous_requester or user_.is_anonymous_requester)
+                         and (not same_agency or changing_more_than_agency_status))
+                        or
+                        # agency admin attempting to change an anonymous requester for a request
+                        # they are not assigned to
+                        (current_user_is_agency_admin and associated_anonymous_requester)))):
             return jsonify({}), 403
 
         # UPDATE
@@ -181,12 +181,12 @@ def patch(user_id):
 
         # check if missing contact information
         if (user_field_val['email'] == ''
-            and user_field_val['phone_number'] == ''
-            and user_field_val['fax_number'] == ''
-            and (address_field_val['city'] == ''
-                 or address_field_val['zip'] == ''
-                 or address_field_val['state'] == ''
-                 or address_field_val['address_one'] == '')):
+                and user_field_val['phone_number'] == ''
+                and user_field_val['fax_number'] == ''
+                and (address_field_val['city'] == ''
+                     or address_field_val['zip'] == ''
+                     or address_field_val['state'] == ''
+                     or address_field_val['address_one'] == '')):
             return jsonify({"error": "Missing contact information."}), 400
 
         old = {}
@@ -307,6 +307,7 @@ def patch(user_id):
                         create_user_request_event(event_type.USER_PERM_CHANGED,
                                                   user_req,
                                                   old_permissions)
+
                     if is_agency_admin:
                         permissions = Roles.query.filter_by(name=role_name.AGENCY_ADMIN).one().permissions
                         # create UserRequests for ALL existing requests under user's agency where user is not assigned
@@ -331,11 +332,13 @@ def patch(user_id):
                                 user_request.request.es_update()
                             else:
                                 set_permissions_and_create_event(user_request, permissions)
+                                user_request.request.es_update()
 
                     else:
                         # update ALL UserRequests (strip user of permissions)
                         for user_request in user_.user_requests.all():
                             set_permissions_and_create_event(user_request, permission.NONE)
+                            user_request.request.es_update()
 
                 # TODO: single email detailing user changes?
 


### PR DESCRIPTION
When a user first logs in to the application, their GUID is changed in the database to reflect the NYC.ID GUID. The ElasticSearch index needs to be updated for the requests where that user is assigned to make sure they can search for their own requests on the search page using the updated GUID.

Additionally, the search index is set to be updated when a user is changed from the agency administration page.