### PR TITLE
Feature/OP-1465: Block Public Access to Environments During Maintenance Windows

### DIFF
--- a/app/templates/error/maintenance.html
+++ b/app/templates/error/maintenance.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}
+    Maintenance
+{% endblock %}
+
+{% block content %}
+    <div class="text-center">
+        <h2>Temporarily Down for Maintenance</h2>
+        <p>We are performing maintenance. We should be back online shortly.</p>
+        {% if description %}
+            <p><strong>What's Happening: </strong> {{ description }}</p>
+        {% else %}
+            <p><strong>What's Happening: </strong> We are performing a scheduled system upgrade</p>
+        {% endif %}
+        {% if outage_time %}
+            <p><strong>Estimated downtime: </strong>{{ outage_time }}</p>
+        {% endif %}
+    </div>
+
+{% endblock %}

--- a/build_scripts/app_setup/app_setup.sh
+++ b/build_scripts/app_setup/app_setup.sh
@@ -57,3 +57,6 @@ echo "source /home/vagrant/.virtualenvs/openrecords/bin/activate" >> /home/vagra
 
 # 9. Setup sudo Access
 cp /vagrant/build_scripts/app_setup/redis /etc/sudoers.d/redis
+
+# 10. Setup Flask Instance Folder
+mkdir -p /vagrant/instance

--- a/build_scripts/default/nginx_conf/sites/error.html
+++ b/build_scripts/default/nginx_conf/sites/error.html
@@ -1,0 +1,210 @@
+<html class="no-js" lang="en" style="height: 100%;">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>
+        Maintenance
+    </title>
+
+    <link rel="stylesheet" type="text/css" href="/static/styles/plugins/bootstrap-theme.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/nyc_gov.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/base.css">
+
+    <link type="image/x-icon" rel="shortcut icon" href="/static/img/favicon-32x32.png">
+
+
+    <link type="text/css" rel="stylesheet" charset="UTF-8" href="https://translate.googleapis.com/translate_static/css/translateelement.css">
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/translate_static/js/element/main.js"></script>
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/element/TE_20170911_00/e/js/element/element_main.js"></script>
+</head>
+
+<body style="position: relative; min-height: 100%; top: 0px;">
+    <div class="nycidm-header">
+        <div class="upper-header-black">
+            <div class="container-nycidm">
+
+                <span class="upper-header-right">
+                    <span class="upper-header-a">
+                        <a href="/auth/login">Log In</a>
+                    </span>
+                </span>
+
+                <span class="upper-header-left">
+                    <a href="http://www1.nyc.gov/">
+                        <img class="small-nyc-logo" alt="NYC Logo" src="/static/img/nyc_white%40x2.png">
+                    </a>
+                    <img class="vert-divide" alt="" src="/static/img/upper-header-divider.gif">
+                    <span class="upper-header-black-title">
+                        OpenRecords
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        "use strict";
+
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'en',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+        }
+    </script>
+    <div class="row">
+        <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+            <a href="/">
+                <img class="center-block header_logo" style="" src="/static/img/logo.png" alt="OpenRecords Logo">
+            </a>
+        </div>
+        <div class="col-sm-2">
+            <div id="google_translate_element">
+                <div class="skiptranslate goog-te-gadget" dir="ltr">
+                    <div id=":0.targetLanguage" class="goog-te-gadget-simple" style="white-space: nowrap; border:none;">
+                        <span style="vertical-align: middle;">
+                            <a role="menu" class="goog-te-menu-value2" href="javascript:void(0)">
+                                <span class="translate-text">Translate</span>
+                                <span style="border-left: 1px solid rgb(187, 187, 187);padding-right:5px;">​</span>
+                                <span style="color: rgb(155, 155, 155);">▼</span>
+                            </a>
+                        </span>
+                        <img src="https://www.google.com/images/cleardot.gif" class="goog-te-gadget-icon" alt="" style="background-image: url(&quot;https://translate.googleapis.com/translate_static/img/te_ctrl3.gif&quot;); background-position: -65px 0px;">
+                        <span style="vertical-align: middle;">
+                            <a aria-haspopup="true" class="goog-te-menu-value" href="javascript:void(0)">
+                                <span>Select Language</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span style="border-left: 1px solid rgb(187, 187, 187);">​</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span aria-hidden="true" style="color: rgb(118, 118, 118);">▼</span>
+                            </a>
+                        </span>
+                    </div>
+                </div>
+                <div class="skiptranslate goog-te-gadget" dir="ltr" style="">
+                    <div id=":0.targetLanguage"></div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-3">&nbsp;</div>
+    </div>
+    <div class="container-fluid">
+        <nav class="navbar navbar-default">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+                        aria-controls="navbar">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                </div>
+                <div id="navbar" class="navbar-collapse collapse">
+                    <ul class="nav navbar-nav">
+                        <li class="openrecords_nav">
+                            <a href="/request/new">Request a Record</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/request/view_all">Search Requests</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/report/show">Reports</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/faq">FAQ</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/about">About</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/contact">Technical Support</a>
+                        </li>
+                    </ul>
+                </div>
+                <!--/.nav-collapse -->
+            </div>
+            <!--/.container-fluid -->
+        </nav>
+    </div>
+    <div class="wrapper">
+        <div class="text-center">
+            <h2>Temporarily Down for Maintenance</h2>
+            <p>The OpenRecords website is currently unvailable due to scheduled maintenance. Please try again later.</p>
+        </div>
+    </div>
+    <div class="footer-wrapper">
+        <!-- // Wrapper -->
+        <footer>
+            <div class="container">
+                <div class="span9 footer-links">
+                    <a href="http://www1.nyc.gov/nyc-resources/agencies.page">Directory of City Agencies</a>
+                    <a href="http://www1.nyc.gov/home/contact-us.page">Contact NYC Government</a>
+                    <a href="https://a127-ess.nyc.gov">City Employees</a>
+                    <a href="http://www.nyc.gov/notifynyc">Notify NYC</a>
+                    <a href="http://a856-citystore.nyc.gov/">CityStore</a>
+                    <a href="http://www1.nyc.gov/connect/social-media.page">Stay Connected
+                    </a>
+                    <a href="http://www1.nyc.gov/connect/applications.page">NYC Mobile Apps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/nyc-maps.page">Maps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/resident-toolkit.page">Resident Toolkit
+                    </a>
+                </div>
+                <div class="span3">
+                    <span class="logo-nyc">NYC</span>
+                    <form class="form-search" method="get" action="http://www1.nyc.gov/home/search/index.page">
+                        <input placeholder="Search" class="input-search placeholder" name="search-terms" type="text">
+                        <button class="ico-search">Search</button>
+                    </form>
+                    <div class="copyright">
+                        <p>City of New York. 2016 All Rights Reserved,</p>
+                        <p>NYC is a trademark and service mark of the City of New York</p>
+                        <p>
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privacy">Privacy Policy</a>.
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <div id="goog-gt-tt" class="skiptranslate" dir="ltr">
+        <div style="padding: 8px;">
+            <div>
+                <div class="logo">
+                    <img src="https://www.gstatic.com/images/branding/product/1x/translate_24dp.png" width="20" height="20" alt="Google Translate">
+                </div>
+            </div>
+        </div>
+        <div class="top" style="padding: 8px; float: left; width: 100%;">
+            <h1 class="title gray">Original text</h1>
+        </div>
+        <div class="middle" style="padding: 8px;">
+            <div class="original-text"></div>
+        </div>
+        <div class="bottom" style="padding: 8px;">
+            <div class="activity-links">
+                <span class="activity-link">Contribute a better translation</span>
+                <span class="activity-link"></span>
+            </div>
+            <div class="started-activity-container">
+                <hr style="color: #CCC; background-color: #CCC; height: 1px; border: none;">
+                <div class="activity-root"></div>
+            </div>
+        </div>
+        <div class="status-message" style="display: none;"></div>
+    </div>
+    <div class="goog-te-spinner-pos">
+        <div class="goog-te-spinner-animation">
+            <svg xmlns="http://www.w3.org/2000/svg" class="goog-te-spinner" width="96px" height="96px" viewBox="0 0 66 66">
+                <circle class="goog-te-spinner-path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle>
+            </svg>
+        </div>
+    </div>
+    <iframe frameborder="0" class="goog-te-menu-frame skiptranslate" title="Language Translate Widget" style="visibility: visible; box-sizing: content-box; width: 1030px; height: 263px; display: none;"></iframe>
+</body>
+
+</html>

--- a/build_scripts/default/nginx_conf/sites/maintenance.html
+++ b/build_scripts/default/nginx_conf/sites/maintenance.html
@@ -1,0 +1,210 @@
+<html class="no-js" lang="en" style="height: 100%;">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>
+        Maintenance
+    </title>
+
+    <link rel="stylesheet" type="text/css" href="/static/styles/plugins/bootstrap-theme.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/nyc_gov.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/base.css">
+
+    <link type="image/x-icon" rel="shortcut icon" href="/static/img/favicon-32x32.png">
+
+
+    <link type="text/css" rel="stylesheet" charset="UTF-8" href="https://translate.googleapis.com/translate_static/css/translateelement.css">
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/translate_static/js/element/main.js"></script>
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/element/TE_20170911_00/e/js/element/element_main.js"></script>
+</head>
+
+<body style="position: relative; min-height: 100%; top: 0px;">
+    <div class="nycidm-header">
+        <div class="upper-header-black">
+            <div class="container-nycidm">
+
+                <span class="upper-header-right">
+                    <span class="upper-header-a">
+                        <a href="/auth/login">Log In</a>
+                    </span>
+                </span>
+
+                <span class="upper-header-left">
+                    <a href="http://www1.nyc.gov/">
+                        <img class="small-nyc-logo" alt="NYC Logo" src="/static/img/nyc_white%40x2.png">
+                    </a>
+                    <img class="vert-divide" alt="" src="/static/img/upper-header-divider.gif">
+                    <span class="upper-header-black-title">
+                        OpenRecords
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        "use strict";
+
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'en',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+        }
+    </script>
+    <div class="row">
+        <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+            <a href="/">
+                <img class="center-block header_logo" style="" src="/static/img/logo.png" alt="OpenRecords Logo">
+            </a>
+        </div>
+        <div class="col-sm-2">
+            <div id="google_translate_element">
+                <div class="skiptranslate goog-te-gadget" dir="ltr">
+                    <div id=":0.targetLanguage" class="goog-te-gadget-simple" style="white-space: nowrap; border:none;">
+                        <span style="vertical-align: middle;">
+                            <a role="menu" class="goog-te-menu-value2" href="javascript:void(0)">
+                                <span class="translate-text">Translate</span>
+                                <span style="border-left: 1px solid rgb(187, 187, 187);padding-right:5px;">​</span>
+                                <span style="color: rgb(155, 155, 155);">▼</span>
+                            </a>
+                        </span>
+                        <img src="https://www.google.com/images/cleardot.gif" class="goog-te-gadget-icon" alt="" style="background-image: url(&quot;https://translate.googleapis.com/translate_static/img/te_ctrl3.gif&quot;); background-position: -65px 0px;">
+                        <span style="vertical-align: middle;">
+                            <a aria-haspopup="true" class="goog-te-menu-value" href="javascript:void(0)">
+                                <span>Select Language</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span style="border-left: 1px solid rgb(187, 187, 187);">​</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span aria-hidden="true" style="color: rgb(118, 118, 118);">▼</span>
+                            </a>
+                        </span>
+                    </div>
+                </div>
+                <div class="skiptranslate goog-te-gadget" dir="ltr" style="">
+                    <div id=":0.targetLanguage"></div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-3">&nbsp;</div>
+    </div>
+    <div class="container-fluid">
+        <nav class="navbar navbar-default">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+                        aria-controls="navbar">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                </div>
+                <div id="navbar" class="navbar-collapse collapse">
+                    <ul class="nav navbar-nav">
+                        <li class="openrecords_nav">
+                            <a href="/request/new">Request a Record</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/request/view_all">Search Requests</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/report/show">Reports</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/faq">FAQ</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/about">About</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/contact">Technical Support</a>
+                        </li>
+                    </ul>
+                </div>
+                <!--/.nav-collapse -->
+            </div>
+            <!--/.container-fluid -->
+        </nav>
+    </div>
+    <div class="wrapper">
+        <div class="text-center">
+            <h2>Temporarily Down for Maintenance</h2>
+            <p>The OpenRecords website is currently unvailable due to scheduled maintenance. Please try again later.</p>
+        </div>
+    </div>
+    <div class="footer-wrapper">
+        <!-- // Wrapper -->
+        <footer>
+            <div class="container">
+                <div class="span9 footer-links">
+                    <a href="http://www1.nyc.gov/nyc-resources/agencies.page">Directory of City Agencies</a>
+                    <a href="http://www1.nyc.gov/home/contact-us.page">Contact NYC Government</a>
+                    <a href="https://a127-ess.nyc.gov">City Employees</a>
+                    <a href="http://www.nyc.gov/notifynyc">Notify NYC</a>
+                    <a href="http://a856-citystore.nyc.gov/">CityStore</a>
+                    <a href="http://www1.nyc.gov/connect/social-media.page">Stay Connected
+                    </a>
+                    <a href="http://www1.nyc.gov/connect/applications.page">NYC Mobile Apps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/nyc-maps.page">Maps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/resident-toolkit.page">Resident Toolkit
+                    </a>
+                </div>
+                <div class="span3">
+                    <span class="logo-nyc">NYC</span>
+                    <form class="form-search" method="get" action="http://www1.nyc.gov/home/search/index.page">
+                        <input placeholder="Search" class="input-search placeholder" name="search-terms" type="text">
+                        <button class="ico-search">Search</button>
+                    </form>
+                    <div class="copyright">
+                        <p>City of New York. 2016 All Rights Reserved,</p>
+                        <p>NYC is a trademark and service mark of the City of New York</p>
+                        <p>
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privacy">Privacy Policy</a>.
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <div id="goog-gt-tt" class="skiptranslate" dir="ltr">
+        <div style="padding: 8px;">
+            <div>
+                <div class="logo">
+                    <img src="https://www.gstatic.com/images/branding/product/1x/translate_24dp.png" width="20" height="20" alt="Google Translate">
+                </div>
+            </div>
+        </div>
+        <div class="top" style="padding: 8px; float: left; width: 100%;">
+            <h1 class="title gray">Original text</h1>
+        </div>
+        <div class="middle" style="padding: 8px;">
+            <div class="original-text"></div>
+        </div>
+        <div class="bottom" style="padding: 8px;">
+            <div class="activity-links">
+                <span class="activity-link">Contribute a better translation</span>
+                <span class="activity-link"></span>
+            </div>
+            <div class="started-activity-container">
+                <hr style="color: #CCC; background-color: #CCC; height: 1px; border: none;">
+                <div class="activity-root"></div>
+            </div>
+        </div>
+        <div class="status-message" style="display: none;"></div>
+    </div>
+    <div class="goog-te-spinner-pos">
+        <div class="goog-te-spinner-animation">
+            <svg xmlns="http://www.w3.org/2000/svg" class="goog-te-spinner" width="96px" height="96px" viewBox="0 0 66 66">
+                <circle class="goog-te-spinner-path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle>
+            </svg>
+        </div>
+    </div>
+    <iframe frameborder="0" class="goog-te-menu-frame skiptranslate" title="Language Translate Widget" style="visibility: visible; box-sizing: content-box; width: 1030px; height: 263px; display: none;"></iframe>
+</body>
+
+</html>

--- a/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
@@ -38,7 +38,7 @@ server {
 
 server {
   set $maintenance_mode 0;
-  error_log                             /vagrant/openrecords_v2_0.nyc.log debug;
+  error_log                             /tmp/openrecords_v2_0.nyc.log debug;
   listen                                443 ssl;
   server_name                           10.0.0.2;
 
@@ -61,7 +61,6 @@ server {
   }
 
   location / {
-    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
     if ($maintenance_mode = 0) {
         set $openrecords_authentication "off";
     }
@@ -70,17 +69,10 @@ server {
     if ($maintenance_mode = 1) {
        add_header Set-Cookie "authorized_maintainer=true;max-age=3153600000;path=/";
     }
-    return 503;
 
     proxy_set_header                    Host $host;
     proxy_set_header                    X-Real-IP $remote_addr;
-    proxy_pass                        http://openrecords_v2_0;
-  }
-
-  error_page 503 @maintenance;
-  location @maintenance {
-    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
-    rewrite ^(.*)$ /maintenance.html break;
+    proxy_pass                          http://openrecords_v2_0;
   }
 
   error_page 401 @unauthorized;
@@ -94,6 +86,15 @@ server {
 
   error_page 403 @forbidden;
   location @forbidden {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    if ($maintenance_mode = 1) {
+        rewrite ^(.*)$ /maintenance.html break;
+    }
+    rewrite ^(.*)$ /error.html break;
+  }
+
+  error_page 503 @maintenance;
+  location @maintenance {
     root /vagrant/build_scripts/web_setup/nginx_conf/sites;
     if ($maintenance_mode = 1) {
         rewrite ^(.*)$ /maintenance.html break;

--- a/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
@@ -61,6 +61,7 @@ server {
   }
 
   location / {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
     if ($maintenance_mode = 0) {
         set $openrecords_authentication "off";
     }
@@ -69,16 +70,26 @@ server {
     if ($maintenance_mode = 1) {
        add_header Set-Cookie "authorized_maintainer=true;max-age=3153600000;path=/";
     }
+    return 503;
 
     proxy_set_header                    Host $host;
     proxy_set_header                    X-Real-IP $remote_addr;
     proxy_pass                        http://openrecords_v2_0;
   }
 
-  error_page 401 @maintenance;
+  error_page 503 @maintenance;
   location @maintenance {
     root /vagrant/build_scripts/web_setup/nginx_conf/sites;
     rewrite ^(.*)$ /maintenance.html break;
+  }
+
+  error_page 401 @unauthorized;
+  location @unauthorized {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    if ($maintenance_mode = 1) {
+        rewrite ^(.*)$ /maintenance.html break;
+    }
+    rewrite ^(.*)$ /error.html break;
   }
 
   error_page 403 @forbidden;

--- a/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
@@ -66,9 +66,6 @@ server {
     }
     auth_basic $openrecords_authentication;
     auth_basic_user_file /vagrant/build_scripts/web_setup/nginx_conf/sites/.htpasswd;
-    if ($maintenance_mode = 1) {
-       add_header Set-Cookie "authorized_maintainer=true;max-age=3153600000;path=/";
-    }
 
     proxy_set_header                    Host $host;
     proxy_set_header                    X-Real-IP $remote_addr;

--- a/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/default/nginx_conf/sites/openrecords_v2_0.conf
@@ -8,6 +8,24 @@ upstream openrecords_v2_0_es {
 
 server_tokens off;
 
+map $cookie_maintenance $openrecords_hascookie {
+  "authorized_maintainer" "yes";
+  default                 "no";
+}
+
+geo $openrecords_geo {
+  10.132.32.0/24  "yes";
+  default         "no";
+}
+
+map $openrecords_hascookie$openrecords_geo $openrecords_authentication{
+  "yesyes" "off";  #both cookie and IP are correct  => OK
+  "yesno"  "off"; #cookie is ok, but IP not  => OK
+  "noyes"  "off";  #cookie is not ok, but IP is ok => OK
+  default  "OpenRecords Maintenance Credentials"; #everythingles => NOT OK
+}
+
+
 server {
     listen                              80;
     server_name                         10.0.0.2;
@@ -19,7 +37,8 @@ server {
 }
 
 server {
-  error_log                             /tmp/openrecords_v2_0.nyc.log debug;
+  set $maintenance_mode 0;
+  error_log                             /vagrant/openrecords_v2_0.nyc.log debug;
   listen                                443 ssl;
   server_name                           10.0.0.2;
 
@@ -42,9 +61,33 @@ server {
   }
 
   location / {
-    proxy_pass                          http://openrecords_v2_0;
+    if ($maintenance_mode = 0) {
+        set $openrecords_authentication "off";
+    }
+    auth_basic $openrecords_authentication;
+    auth_basic_user_file /vagrant/build_scripts/web_setup/nginx_conf/sites/.htpasswd;
+    if ($maintenance_mode = 1) {
+       add_header Set-Cookie "authorized_maintainer=true;max-age=3153600000;path=/";
+    }
+
     proxy_set_header                    Host $host;
     proxy_set_header                    X-Real-IP $remote_addr;
+    proxy_pass                        http://openrecords_v2_0;
+  }
+
+  error_page 401 @maintenance;
+  location @maintenance {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    rewrite ^(.*)$ /maintenance.html break;
+  }
+
+  error_page 403 @forbidden;
+  location @forbidden {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    if ($maintenance_mode = 1) {
+        rewrite ^(.*)$ /maintenance.html break;
+    }
+    rewrite ^(.*)$ /error.html break;
   }
 }
 

--- a/build_scripts/web_setup/nginx_conf/sites/error.html
+++ b/build_scripts/web_setup/nginx_conf/sites/error.html
@@ -1,0 +1,210 @@
+<html class="no-js" lang="en" style="height: 100%;">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>
+        Maintenance
+    </title>
+
+    <link rel="stylesheet" type="text/css" href="/static/styles/plugins/bootstrap-theme.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/nyc_gov.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/base.css">
+
+    <link type="image/x-icon" rel="shortcut icon" href="/static/img/favicon-32x32.png">
+
+
+    <link type="text/css" rel="stylesheet" charset="UTF-8" href="https://translate.googleapis.com/translate_static/css/translateelement.css">
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/translate_static/js/element/main.js"></script>
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/element/TE_20170911_00/e/js/element/element_main.js"></script>
+</head>
+
+<body style="position: relative; min-height: 100%; top: 0px;">
+    <div class="nycidm-header">
+        <div class="upper-header-black">
+            <div class="container-nycidm">
+
+                <span class="upper-header-right">
+                    <span class="upper-header-a">
+                        <a href="/auth/login">Log In</a>
+                    </span>
+                </span>
+
+                <span class="upper-header-left">
+                    <a href="http://www1.nyc.gov/">
+                        <img class="small-nyc-logo" alt="NYC Logo" src="/static/img/nyc_white%40x2.png">
+                    </a>
+                    <img class="vert-divide" alt="" src="/static/img/upper-header-divider.gif">
+                    <span class="upper-header-black-title">
+                        OpenRecords
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        "use strict";
+
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'en',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+        }
+    </script>
+    <div class="row">
+        <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+            <a href="/">
+                <img class="center-block header_logo" style="" src="/static/img/logo.png" alt="OpenRecords Logo">
+            </a>
+        </div>
+        <div class="col-sm-2">
+            <div id="google_translate_element">
+                <div class="skiptranslate goog-te-gadget" dir="ltr">
+                    <div id=":0.targetLanguage" class="goog-te-gadget-simple" style="white-space: nowrap; border:none;">
+                        <span style="vertical-align: middle;">
+                            <a role="menu" class="goog-te-menu-value2" href="javascript:void(0)">
+                                <span class="translate-text">Translate</span>
+                                <span style="border-left: 1px solid rgb(187, 187, 187);padding-right:5px;">​</span>
+                                <span style="color: rgb(155, 155, 155);">▼</span>
+                            </a>
+                        </span>
+                        <img src="https://www.google.com/images/cleardot.gif" class="goog-te-gadget-icon" alt="" style="background-image: url(&quot;https://translate.googleapis.com/translate_static/img/te_ctrl3.gif&quot;); background-position: -65px 0px;">
+                        <span style="vertical-align: middle;">
+                            <a aria-haspopup="true" class="goog-te-menu-value" href="javascript:void(0)">
+                                <span>Select Language</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span style="border-left: 1px solid rgb(187, 187, 187);">​</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span aria-hidden="true" style="color: rgb(118, 118, 118);">▼</span>
+                            </a>
+                        </span>
+                    </div>
+                </div>
+                <div class="skiptranslate goog-te-gadget" dir="ltr" style="">
+                    <div id=":0.targetLanguage"></div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-3">&nbsp;</div>
+    </div>
+    <div class="container-fluid">
+        <nav class="navbar navbar-default">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+                        aria-controls="navbar">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                </div>
+                <div id="navbar" class="navbar-collapse collapse">
+                    <ul class="nav navbar-nav">
+                        <li class="openrecords_nav">
+                            <a href="/request/new">Request a Record</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/request/view_all">Search Requests</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/report/show">Reports</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/faq">FAQ</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/about">About</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/contact">Technical Support</a>
+                        </li>
+                    </ul>
+                </div>
+                <!--/.nav-collapse -->
+            </div>
+            <!--/.container-fluid -->
+        </nav>
+    </div>
+    <div class="wrapper">
+        <div class="text-center">
+            <h2>Temporarily Down for Maintenance</h2>
+            <p>The OpenRecords website is currently unvailable due to scheduled maintenance. Please try again later.</p>
+        </div>
+    </div>
+    <div class="footer-wrapper">
+        <!-- // Wrapper -->
+        <footer>
+            <div class="container">
+                <div class="span9 footer-links">
+                    <a href="http://www1.nyc.gov/nyc-resources/agencies.page">Directory of City Agencies</a>
+                    <a href="http://www1.nyc.gov/home/contact-us.page">Contact NYC Government</a>
+                    <a href="https://a127-ess.nyc.gov">City Employees</a>
+                    <a href="http://www.nyc.gov/notifynyc">Notify NYC</a>
+                    <a href="http://a856-citystore.nyc.gov/">CityStore</a>
+                    <a href="http://www1.nyc.gov/connect/social-media.page">Stay Connected
+                    </a>
+                    <a href="http://www1.nyc.gov/connect/applications.page">NYC Mobile Apps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/nyc-maps.page">Maps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/resident-toolkit.page">Resident Toolkit
+                    </a>
+                </div>
+                <div class="span3">
+                    <span class="logo-nyc">NYC</span>
+                    <form class="form-search" method="get" action="http://www1.nyc.gov/home/search/index.page">
+                        <input placeholder="Search" class="input-search placeholder" name="search-terms" type="text">
+                        <button class="ico-search">Search</button>
+                    </form>
+                    <div class="copyright">
+                        <p>City of New York. 2016 All Rights Reserved,</p>
+                        <p>NYC is a trademark and service mark of the City of New York</p>
+                        <p>
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privacy">Privacy Policy</a>.
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <div id="goog-gt-tt" class="skiptranslate" dir="ltr">
+        <div style="padding: 8px;">
+            <div>
+                <div class="logo">
+                    <img src="https://www.gstatic.com/images/branding/product/1x/translate_24dp.png" width="20" height="20" alt="Google Translate">
+                </div>
+            </div>
+        </div>
+        <div class="top" style="padding: 8px; float: left; width: 100%;">
+            <h1 class="title gray">Original text</h1>
+        </div>
+        <div class="middle" style="padding: 8px;">
+            <div class="original-text"></div>
+        </div>
+        <div class="bottom" style="padding: 8px;">
+            <div class="activity-links">
+                <span class="activity-link">Contribute a better translation</span>
+                <span class="activity-link"></span>
+            </div>
+            <div class="started-activity-container">
+                <hr style="color: #CCC; background-color: #CCC; height: 1px; border: none;">
+                <div class="activity-root"></div>
+            </div>
+        </div>
+        <div class="status-message" style="display: none;"></div>
+    </div>
+    <div class="goog-te-spinner-pos">
+        <div class="goog-te-spinner-animation">
+            <svg xmlns="http://www.w3.org/2000/svg" class="goog-te-spinner" width="96px" height="96px" viewBox="0 0 66 66">
+                <circle class="goog-te-spinner-path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle>
+            </svg>
+        </div>
+    </div>
+    <iframe frameborder="0" class="goog-te-menu-frame skiptranslate" title="Language Translate Widget" style="visibility: visible; box-sizing: content-box; width: 1030px; height: 263px; display: none;"></iframe>
+</body>
+
+</html>

--- a/build_scripts/web_setup/nginx_conf/sites/maintenance.html
+++ b/build_scripts/web_setup/nginx_conf/sites/maintenance.html
@@ -1,0 +1,210 @@
+<html class="no-js" lang="en" style="height: 100%;">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>
+        Maintenance
+    </title>
+
+    <link rel="stylesheet" type="text/css" href="/static/styles/plugins/bootstrap-theme.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/nyc_gov.css">
+    <link rel="stylesheet" type="text/css" href="/static/styles/base.css">
+
+    <link type="image/x-icon" rel="shortcut icon" href="/static/img/favicon-32x32.png">
+
+
+    <link type="text/css" rel="stylesheet" charset="UTF-8" href="https://translate.googleapis.com/translate_static/css/translateelement.css">
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/translate_static/js/element/main.js"></script>
+    <script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/element/TE_20170911_00/e/js/element/element_main.js"></script>
+</head>
+
+<body style="position: relative; min-height: 100%; top: 0px;">
+    <div class="nycidm-header">
+        <div class="upper-header-black">
+            <div class="container-nycidm">
+
+                <span class="upper-header-right">
+                    <span class="upper-header-a">
+                        <a href="/auth/login">Log In</a>
+                    </span>
+                </span>
+
+                <span class="upper-header-left">
+                    <a href="http://www1.nyc.gov/">
+                        <img class="small-nyc-logo" alt="NYC Logo" src="/static/img/nyc_white%40x2.png">
+                    </a>
+                    <img class="vert-divide" alt="" src="/static/img/upper-header-divider.gif">
+                    <span class="upper-header-black-title">
+                        OpenRecords
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        "use strict";
+
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({
+                pageLanguage: 'en',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+            }, 'google_translate_element');
+        }
+    </script>
+    <div class="row">
+        <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+            <a href="/">
+                <img class="center-block header_logo" style="" src="/static/img/logo.png" alt="OpenRecords Logo">
+            </a>
+        </div>
+        <div class="col-sm-2">
+            <div id="google_translate_element">
+                <div class="skiptranslate goog-te-gadget" dir="ltr">
+                    <div id=":0.targetLanguage" class="goog-te-gadget-simple" style="white-space: nowrap; border:none;">
+                        <span style="vertical-align: middle;">
+                            <a role="menu" class="goog-te-menu-value2" href="javascript:void(0)">
+                                <span class="translate-text">Translate</span>
+                                <span style="border-left: 1px solid rgb(187, 187, 187);padding-right:5px;">​</span>
+                                <span style="color: rgb(155, 155, 155);">▼</span>
+                            </a>
+                        </span>
+                        <img src="https://www.google.com/images/cleardot.gif" class="goog-te-gadget-icon" alt="" style="background-image: url(&quot;https://translate.googleapis.com/translate_static/img/te_ctrl3.gif&quot;); background-position: -65px 0px;">
+                        <span style="vertical-align: middle;">
+                            <a aria-haspopup="true" class="goog-te-menu-value" href="javascript:void(0)">
+                                <span>Select Language</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span style="border-left: 1px solid rgb(187, 187, 187);">​</span>
+                                <img src="https://www.google.com/images/cleardot.gif" alt="" width="1" height="1">
+                                <span aria-hidden="true" style="color: rgb(118, 118, 118);">▼</span>
+                            </a>
+                        </span>
+                    </div>
+                </div>
+                <div class="skiptranslate goog-te-gadget" dir="ltr" style="">
+                    <div id=":0.targetLanguage"></div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-3">&nbsp;</div>
+    </div>
+    <div class="container-fluid">
+        <nav class="navbar navbar-default">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+                        aria-controls="navbar">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                </div>
+                <div id="navbar" class="navbar-collapse collapse">
+                    <ul class="nav navbar-nav">
+                        <li class="openrecords_nav">
+                            <a href="/request/new">Request a Record</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/request/view_all">Search Requests</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/report/show">Reports</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/faq">FAQ</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/about">About</a>
+                        </li>
+                        <li class="openrecords_nav">
+                            <a href="/contact">Technical Support</a>
+                        </li>
+                    </ul>
+                </div>
+                <!--/.nav-collapse -->
+            </div>
+            <!--/.container-fluid -->
+        </nav>
+    </div>
+    <div class="wrapper">
+        <div class="text-center">
+            <h2>Temporarily Down for Maintenance</h2>
+            <p>The OpenRecords website is currently unvailable due to scheduled maintenance. Please try again later.</p>
+        </div>
+    </div>
+    <div class="footer-wrapper">
+        <!-- // Wrapper -->
+        <footer>
+            <div class="container">
+                <div class="span9 footer-links">
+                    <a href="http://www1.nyc.gov/nyc-resources/agencies.page">Directory of City Agencies</a>
+                    <a href="http://www1.nyc.gov/home/contact-us.page">Contact NYC Government</a>
+                    <a href="https://a127-ess.nyc.gov">City Employees</a>
+                    <a href="http://www.nyc.gov/notifynyc">Notify NYC</a>
+                    <a href="http://a856-citystore.nyc.gov/">CityStore</a>
+                    <a href="http://www1.nyc.gov/connect/social-media.page">Stay Connected
+                    </a>
+                    <a href="http://www1.nyc.gov/connect/applications.page">NYC Mobile Apps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/nyc-maps.page">Maps</a>
+                    <a href="http://www1.nyc.gov/nyc-resources/resident-toolkit.page">Resident Toolkit
+                    </a>
+                </div>
+                <div class="span3">
+                    <span class="logo-nyc">NYC</span>
+                    <form class="form-search" method="get" action="http://www1.nyc.gov/home/search/index.page">
+                        <input placeholder="Search" class="input-search placeholder" name="search-terms" type="text">
+                        <button class="ico-search">Search</button>
+                    </form>
+                    <div class="copyright">
+                        <p>City of New York. 2016 All Rights Reserved,</p>
+                        <p>NYC is a trademark and service mark of the City of New York</p>
+                        <p>
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privacy">Privacy Policy</a>.
+                            <a target="_blank" rel="noopener noreferrer" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <div id="goog-gt-tt" class="skiptranslate" dir="ltr">
+        <div style="padding: 8px;">
+            <div>
+                <div class="logo">
+                    <img src="https://www.gstatic.com/images/branding/product/1x/translate_24dp.png" width="20" height="20" alt="Google Translate">
+                </div>
+            </div>
+        </div>
+        <div class="top" style="padding: 8px; float: left; width: 100%;">
+            <h1 class="title gray">Original text</h1>
+        </div>
+        <div class="middle" style="padding: 8px;">
+            <div class="original-text"></div>
+        </div>
+        <div class="bottom" style="padding: 8px;">
+            <div class="activity-links">
+                <span class="activity-link">Contribute a better translation</span>
+                <span class="activity-link"></span>
+            </div>
+            <div class="started-activity-container">
+                <hr style="color: #CCC; background-color: #CCC; height: 1px; border: none;">
+                <div class="activity-root"></div>
+            </div>
+        </div>
+        <div class="status-message" style="display: none;"></div>
+    </div>
+    <div class="goog-te-spinner-pos">
+        <div class="goog-te-spinner-animation">
+            <svg xmlns="http://www.w3.org/2000/svg" class="goog-te-spinner" width="96px" height="96px" viewBox="0 0 66 66">
+                <circle class="goog-te-spinner-path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle>
+            </svg>
+        </div>
+    </div>
+    <iframe frameborder="0" class="goog-te-menu-frame skiptranslate" title="Language Translate Widget" style="visibility: visible; box-sizing: content-box; width: 1030px; height: 263px; display: none;"></iframe>
+</body>
+
+</html>

--- a/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
@@ -62,9 +62,6 @@ server {
     }
     auth_basic $openrecords_authentication;
     auth_basic_user_file /vagrant/build_scripts/web_setup/nginx_conf/sites/.htpasswd;
-    if ($maintenance_mode = 1) {
-       add_header Set-Cookie "authorized_maintainer=true;max-age=3153600000;path=/";
-    }
 
     proxy_set_header                    Host $host;
     proxy_set_header                    X-Real-IP $remote_addr;

--- a/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
@@ -71,10 +71,19 @@ server {
     proxy_pass                        http://openrecords_v2_0;
   }
 
-  error_page 401 @maintenance;
+  error_page 503 @maintenance;
   location @maintenance {
     root /vagrant/build_scripts/web_setup/nginx_conf/sites;
     rewrite ^(.*)$ /maintenance.html break;
+  }
+
+  error_page 401 @unauthorized;
+  location @unauthorized {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    if ($maintenance_mode = 1) {
+        rewrite ^(.*)$ /maintenance.html break;
+    }
+    rewrite ^(.*)$ /error.html break;
   }
 
   error_page 403 @forbidden;

--- a/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
@@ -4,6 +4,24 @@ upstream openrecords_v2_0 {
 
 server_tokens off;
 
+map $cookie_maintenance $openrecords_hascookie {
+  "authorized_maintainer" "yes";
+  default                 "no";
+}
+
+geo $openrecords_geo {
+  10.132.32.0/24  "yes";
+  default         "no";
+}
+
+map $openrecords_hascookie$openrecords_geo $openrecords_authentication{
+  "yesyes" "off";  #both cookie and IP are correct  => OK
+  "yesno"  "off"; #cookie is ok, but IP not  => OK
+  "noyes"  "off";  #cookie is not ok, but IP is ok => OK
+  default  "OpenRecords Maintenance Credentials"; #everythingles => NOT OK
+}
+
+
 server {
     listen                              80;
     server_name                         10.0.0.2;
@@ -15,7 +33,8 @@ server {
 }
 
 server {
-  error_log                             /tmp/openrecords_v2_0.nyc.log debug;
+  set $maintenance_mode 0;
+  error_log                             /vagrant/openrecords_v2_0.nyc.log debug;
   listen                                443 ssl;
   server_name                           10.0.0.2;
 
@@ -32,9 +51,38 @@ server {
   ssl_protocols                         TLSv1.1 TLSv1.2;
   ssl_ciphers                           ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
 
+  location /static/ {
+    root /vagrant/app/;
+    access_log off;
+  }
+
   location / {
-    proxy_pass                          https://openrecords_v2_0;
+    if ($maintenance_mode = 0) {
+        set $openrecords_authentication "off";
+    }
+    auth_basic $openrecords_authentication;
+    auth_basic_user_file /vagrant/build_scripts/web_setup/nginx_conf/sites/.htpasswd;
+    if ($maintenance_mode = 1) {
+       add_header Set-Cookie "authorized_maintainer=true;max-age=3153600000;path=/";
+    }
+
     proxy_set_header                    Host $host;
     proxy_set_header                    X-Real-IP $remote_addr;
+    proxy_pass                        http://openrecords_v2_0;
+  }
+
+  error_page 401 @maintenance;
+  location @maintenance {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    rewrite ^(.*)$ /maintenance.html break;
+  }
+
+  error_page 403 @forbidden;
+  location @forbidden {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    if ($maintenance_mode = 1) {
+        rewrite ^(.*)$ /maintenance.html break;
+    }
+    rewrite ^(.*)$ /error.html break;
   }
 }

--- a/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
+++ b/build_scripts/web_setup/nginx_conf/sites/openrecords_v2_0.conf
@@ -1,5 +1,5 @@
 upstream openrecords_v2_0 {
-    server 10.0.0.3:8443;
+    server localhost:5000;
 }
 
 server_tokens off;
@@ -34,7 +34,7 @@ server {
 
 server {
   set $maintenance_mode 0;
-  error_log                             /vagrant/openrecords_v2_0.nyc.log debug;
+  error_log                             /tmp/openrecords_v2_0.nyc.log debug;
   listen                                443 ssl;
   server_name                           10.0.0.2;
 
@@ -68,13 +68,7 @@ server {
 
     proxy_set_header                    Host $host;
     proxy_set_header                    X-Real-IP $remote_addr;
-    proxy_pass                        http://openrecords_v2_0;
-  }
-
-  error_page 503 @maintenance;
-  location @maintenance {
-    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
-    rewrite ^(.*)$ /maintenance.html break;
+    proxy_pass                          http://openrecords_v2_0;
   }
 
   error_page 401 @unauthorized;
@@ -88,6 +82,15 @@ server {
 
   error_page 403 @forbidden;
   location @forbidden {
+    root /vagrant/build_scripts/web_setup/nginx_conf/sites;
+    if ($maintenance_mode = 1) {
+        rewrite ^(.*)$ /maintenance.html break;
+    }
+    rewrite ^(.*)$ /error.html break;
+  }
+
+  error_page 503 @maintenance;
+  location @maintenance {
     root /vagrant/build_scripts/web_setup/nginx_conf/sites;
     if ($maintenance_mode = 1) {
         rewrite ^(.*)$ /maintenance.html break;

--- a/maintenance.json
+++ b/maintenance.json
@@ -1,0 +1,4 @@
+{
+  "description": "We are currently upgrading the OpenRecords system.",
+  "outage_time": "5:00 PM EST - 8:00 PM EST"
+}


### PR DESCRIPTION
This pull request provides two implementations that can be used to limit access during a maintenance window.

Both implementations rely on cookies to provide the most basic form of authentication. If a user has the authorized_maintainer cookie set in their browser, they will be allowed to continue to the application, otherwise, the user is sent to a maintenance page with a 503 Status Code.

The two implementations are as follows:
**1) Flask (Preferred)**
Using the built in error handlers (abort), a user is sent to the maintenance page (with 503 Status Code) when a file is added to the `app.instance_path`. Currently the system looks for a `maintenance.json` file to exist in the instance path. 

   The contents of the `maintenance.json` provide a description and an estimated outage time for the application.  

   The format of the file should be as follows:
   ```json
   { 
     "description": "Simple description of the reason for maintenance (e.g. system upgrade, critical error, etc.)",
     "outage_time": "Human readable description of the estimated outage duration (e.g. 5:00 PM EST until 7:00 PM EST)"
   }
   ```
   
   Flask instance folders are loaded dynamically, which allows us to put the system in maintenance mode without actually reloading `nginx`, which I believe is a plus.

   We should also probably look into setting up systemd for Gunicorn to gracefully reload our code with a minimum of downtime [(Gunicorn systemd Documentation)](http://docs.gunicorn.org/en/stable/deploy.html#systemd)

**2) Nginx Configuration**
   Following the information provided in this article: (No nginx basic auth with either network or cookie set)[https://www.liip.ch/en/blog/no-nginx-basic-auth-with-either-network-or-cookie-set].

   IP based rules have been setup to allow an internal network (10.132.32.0/24) and set to deny all others.

   A cookie entry has been added for the `authorized_maintainer` cookie as well.

   If at least one of the values is `yes`, then the user is allowed to access the application. Otherwise, HTTP Basic Authentication is brought up and the user is prompted to enter a username and password.

   If the username and password are correct, then the the cookie will be added to the browser for the user. Otherwise, they are redirected to an error page for maintenance (slightly different from the 503 maintenance page). 

Note: To create an `.htpasswd` file for use with Nginx, run the following command:
`printf "USER:$(openssl passwd -crypt PASSWORD)\n" >> .htpasswd` where USER is your username and PASSWORD is your password. 

Nginx looks for the .htpasswd file to be stored in `/vagrant/build_scripts/web_setup/nginx_conf/sites/.htpasswd;` (stored with the site configuration).
   

<details>
<summary>OP-1456 - Block Public Access to Environments During Maintenance Windows</summary>

As a developer / QA analyst, I need to prevent the public / agencies from accessing OpenRecords when running smoke tests, to prevent data loss.

**Acceptance Criteria:**
- Identify specific machines / IP addresses that are allowed to access OpenRecords
- Deny all others

**Estimates:** 
Development: 14h
Code Review: 3h
QA: 1h