### PR TITLE
Feature/OP-1438: Display Custom Request Metadata on View Request Page

### DIFF
--- a/app/constants/schemas/agencies.schema
+++ b/app/constants/schemas/agencies.schema
@@ -134,6 +134,17 @@
                 true,
                 false
               ]
+            },
+            "expand_by_default": {
+              "$id": "/properties/agencies/items/properties/agency_features/properties/custom_request_types/properties/expand_by_default",
+              "type": "boolean",
+              "title": "Expand By Default",
+              "default": false,
+              "description": "Boolean to determine if the custom request form data should be expanded on the request page",
+              "examples": [
+                true,
+                false
+              ]
             }
           }
         }

--- a/app/request/views.py
+++ b/app/request/views.py
@@ -300,11 +300,16 @@ def view(request_id):
                   not current_request.privacy['title'])
 
     # Determine if "Generate Letter" functionality is enabled for the agency.
-
     if 'letters' in current_request.agency.agency_features:
         generate_letters_enabled = current_request.agency.agency_features['letters']['generate_letters']
     else:
         generate_letters_enabled = False
+
+    # Determine if custom request form panels should be expanded by default
+    if 'expand_by_default' in current_request.agency.agency_features['custom_request_forms']:
+        expand_by_default = current_request.agency.agency_features['custom_request_forms']['expand_by_default']
+    else:
+        expand_by_default = False
 
     return render_template(
         'request/view_request.html',
@@ -334,7 +339,8 @@ def view(request_id):
         show_title=show_title,
         is_requester=(current_request.requester == current_user),
         permissions_length=len(permission.ALL),
-        generate_letters_enabled=generate_letters_enabled
+        generate_letters_enabled=generate_letters_enabled,
+        expand_by_default=expand_by_default
     )
 
 

--- a/app/templates/request/_view_request_info.html
+++ b/app/templates/request/_view_request_info.html
@@ -52,6 +52,38 @@
                     <br>
                 </div>
             {% endif %}
+            {% if request.custom_metadata and (current_user.is_agency or is_requester) %}
+                <div class="row">
+                    <div class="request-label lead">Request Information:</div><br>
+                    {% for form_number,form_values in request.custom_metadata|dictsort %}
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <div class="panel-title">
+                                    <a data-toggle="collapse"
+                                       href="#collapse-{{ loop.index }}">{{ form_values['form_name'] }}</a>
+                                </div>
+                            </div>
+                            <div id="collapse-{{ loop.index }}" class="panel-collapse collapse {% if expand_by_default %}in{% endif %}">
+                                <div class="panel-body lead" style="padding: 15px !important;">
+                                    {% for field_number,field_values in form_values['form_fields']|dictsort %}
+                                        {{ field_values['field_name'] }}:
+                                        {% if field_values['field_value'] is iterable and field_values['field_value'] is not string %}
+                                            {% for value in field_values['field_value'] %}
+                                                {{ value }}
+                                                {% if field_values['field_value']|length > 1 and loop.index != field_values['field_value']|length %}
+                                                    , {% endif %}
+                                            {% endfor %}
+                                        {% else %}
+                                            {{ field_values['field_value'] }}
+                                        {% endif %}
+                                        <br/>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endif %}
             <div class="row">
                 {% if show_agency_request_summary %}
                     <div class="request-label lead col-sm-6">Agency Request Summary:</div>
@@ -109,26 +141,6 @@
                         {% endif %}
                     </div>
                 </div>
-            {% endif %}
-            {% if request.custom_metadata and current_user in request.agency_users %}
-                <br>
-                {% for form_number,form_values in request.custom_metadata|dictsort %}
-                    <u class="request-label lead">{{ form_values['form_name'] }}</u>
-                    <br/>
-                    {% for field_number,field_values in form_values['form_fields']|dictsort %}
-                        {{ field_values['field_name'] }}:
-                        {% if field_values['field_value'] is iterable and field_values['field_value'] is not string %}
-                            {% for value in field_values['field_value'] %}
-                                {{ value }}
-                                        {% if field_values['field_value']|length > 1 and loop.index != field_values['field_value']|length %}, {% endif %}
-                            {% endfor %}
-                        {% else %}
-                            {{ field_values['field_value'] }}
-                        {% endif %}
-                        <br/>
-                    {% endfor %}
-                    <br/>
-                {% endfor %}
             {% endif %}
         </div>
     </div>

--- a/data/agencies.json
+++ b/data/agencies.json
@@ -23,7 +23,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -50,7 +51,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -77,7 +79,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -104,7 +107,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -131,7 +135,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -158,7 +163,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -185,7 +191,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -212,7 +219,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -239,7 +247,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -266,7 +275,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -293,7 +303,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -320,7 +331,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -347,7 +359,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -374,7 +387,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -401,7 +415,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -428,7 +443,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -455,7 +471,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -482,7 +499,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -509,7 +527,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -536,7 +555,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -563,7 +583,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -590,7 +611,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -617,7 +639,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -644,7 +667,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -671,7 +695,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -698,7 +723,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -725,7 +751,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -752,7 +779,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -779,7 +807,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -806,7 +835,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -833,7 +863,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -860,7 +891,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -887,7 +919,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -914,7 +947,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -941,7 +975,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -968,7 +1003,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -995,7 +1031,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1022,7 +1059,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1049,7 +1087,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1076,7 +1115,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1103,7 +1143,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1130,7 +1171,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1157,7 +1199,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1184,7 +1227,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1211,7 +1255,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1238,7 +1283,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1265,7 +1311,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1292,7 +1339,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1319,7 +1367,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1346,7 +1395,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1373,7 +1423,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1400,7 +1451,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1427,7 +1479,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1454,7 +1507,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1481,7 +1535,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1508,7 +1563,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1535,7 +1591,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1562,7 +1619,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1589,7 +1647,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1616,7 +1675,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1643,7 +1703,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1670,7 +1731,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1702,7 +1764,8 @@
         },
         "custom_request_forms": {
           "enabled": true,
-          "multiple_request_types": true
+          "multiple_request_types": true,
+          "expand_by_default": false
         }
       }
     },
@@ -1729,7 +1792,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1756,7 +1820,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1783,7 +1848,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1810,7 +1876,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1837,7 +1904,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1865,7 +1933,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1892,7 +1961,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1919,7 +1989,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1946,7 +2017,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1973,7 +2045,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -2000,7 +2073,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     }

--- a/data/agencies_test.json
+++ b/data/agencies_test.json
@@ -23,7 +23,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -50,7 +51,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -77,7 +79,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -104,7 +107,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -131,7 +135,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -158,7 +163,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -185,7 +191,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -212,7 +219,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -239,7 +247,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -266,7 +275,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -293,7 +303,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -320,7 +331,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -347,7 +359,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -374,7 +387,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -401,7 +415,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -428,7 +443,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -455,7 +471,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -482,7 +499,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -509,7 +527,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -536,7 +555,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -563,7 +583,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -590,7 +611,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -617,7 +639,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -644,7 +667,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -671,7 +695,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -698,7 +723,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -725,7 +751,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -752,7 +779,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -779,7 +807,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -806,7 +835,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -833,7 +863,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -860,7 +891,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -887,7 +919,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -914,7 +947,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -941,7 +975,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -968,7 +1003,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1024,7 +1060,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1051,7 +1088,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1078,7 +1116,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1105,7 +1144,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1132,7 +1172,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1159,7 +1200,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1186,7 +1228,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1213,7 +1256,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1240,7 +1284,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1267,7 +1312,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1294,7 +1340,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1321,7 +1368,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1348,7 +1396,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1375,7 +1424,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1402,7 +1452,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1429,7 +1480,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1456,7 +1508,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1483,7 +1536,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1510,7 +1564,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1537,7 +1592,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1564,7 +1620,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1591,7 +1648,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1618,7 +1676,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1645,7 +1704,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1672,7 +1732,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1705,7 +1766,8 @@
         },
         "custom_request_forms": {
           "enabled": true,
-          "multiple_request_types": true
+          "multiple_request_types": true,
+          "expand_by_default": false
         }
       }
     },
@@ -1732,7 +1794,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1759,7 +1822,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1786,7 +1850,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1813,7 +1878,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1840,7 +1906,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1867,7 +1934,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1894,7 +1962,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1921,7 +1990,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1948,7 +2018,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -1975,7 +2046,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     },
@@ -2002,7 +2074,8 @@
         },
         "custom_request_forms": {
           "enabled": false,
-          "multiple_request_types": false
+          "multiple_request_types": false,
+          "expand_by_default": false
         }
       }
     }

--- a/data/custom_request_forms.json
+++ b/data/custom_request_forms.json
@@ -183,6 +183,83 @@
         }
       ],
       "repeatable": "3"
+    },
+    {
+      "agency_ein": "0056",
+      "form_name": "Body Worn Camera Video",
+      "field_definitions": [
+        {
+          "Date of Incident": {
+            "type": "date",
+            "name": "date-of-incident",
+            "required": false
+          }
+        },
+        {
+          "Start Time": {
+            "type": "time",
+            "name": "start-time",
+            "required": false
+          }
+        },
+        {
+          "End Time": {
+            "type": "time",
+            "name": "end-time",
+            "required": false
+          }
+        },
+        {
+          "Location": {
+            "type": "input",
+            "name": "bwc-location",
+            "required": false
+          }
+        },
+        {
+          "Precinct Number": {
+            "type": "input",
+            "name": "precinct-number",
+            "required": false
+          }
+        },
+        {
+          "Type of Incident/Reason": {
+            "type": "input",
+            "name": "type-of-incident",
+            "required": false
+          }
+        },
+        {
+          "Officer's Name": {
+            "type": "input",
+            "name": "officers-name",
+            "required": false
+          }
+        },
+        {
+          "Arrest Number": {
+            "type": "input",
+            "name": "arrest-number",
+            "required": false
+          }
+        },
+        {
+          "Complaint Number": {
+            "type": "input",
+            "name": "complaint-number",
+            "required": false
+          }
+        },
+        {
+          "Other Police Incident Number": {
+            "type": "input",
+            "name": "other-police-incident-number",
+            "required": false
+          }
+        }
+      ],
+      "repeatable": "1"
     }
   ]
 }


### PR DESCRIPTION
I added an additional option to the custom_request_forms section of agency features.

`"expand_by_default": true` will cause the panels to be expanded when you first load the request page
`"expand_by_default": false` will cause the panels to be collapsed when you first load the request page

Make sure you reload the agency features column, otherwise the default value for `expand_by_default` will be `False`
