### PR TITLE
Feature/OP-1505: Add Form Description for Custom Forms

### DIFF
--- a/app/agency/api/views.py
+++ b/app/agency/api/views.py
@@ -84,7 +84,8 @@ def get_custom_request_form_fields():
     repeatable_counter = json.loads(request.args['repeatable_counter'])
     instance_id = custom_request_form.repeatable - repeatable_counter[str(custom_request_form.id)] + 1
 
-    form_template = ''
+    form_template = render_template('custom_request_form_templates/form_description_template.html',
+                                    form_description=custom_request_form.form_description)
     for field in custom_request_form.field_definitions:
         for key, value in field.items():
             field_text = key

--- a/app/models.py
+++ b/app/models.py
@@ -1887,7 +1887,7 @@ class CustomRequestForms(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     agency_ein = db.Column(db.String(4), db.ForeignKey('agencies.ein'), nullable=False)
     form_name = db.Column(db.String, nullable=False)
-    form_description = db.Column(db.String, nullable=True)
+    form_description = db.Column(db.String, nullable=False)
     field_definitions = db.Column(JSONB, nullable=False)
     repeatable = db.Column(db.Integer, nullable=False)
     category = db.Column(db.Integer, nullable=True)

--- a/app/models.py
+++ b/app/models.py
@@ -1878,6 +1878,7 @@ class CustomRequestForms(db.Model):
     id - an integer that is the primary key of CustomRequestForms
     agency_ein - a string that is a foreign key to the Agencies table
     form_name - a string that is the name of the custom form
+    form_description - a string that prompts the user what the form is about and how to fill it out
     field_definitions - a JSON that contains the the name of the field as the key and type of field as the value
     repeatable - an integer the determines if that form is repeatable. 0 = not repeatable, 1 = can be added twice, etc.
     category - an integer to separate different types of custom forms for an agency
@@ -1886,6 +1887,7 @@ class CustomRequestForms(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     agency_ein = db.Column(db.String(4), db.ForeignKey('agencies.ein'), nullable=False)
     form_name = db.Column(db.String, nullable=False)
+    form_description = db.Column(db.String, nullable=True)
     field_definitions = db.Column(JSONB, nullable=False)
     repeatable = db.Column(db.Integer, nullable=False)
     category = db.Column(db.Integer, nullable=True)
@@ -1907,6 +1909,7 @@ class CustomRequestForms(db.Model):
                 custom_request_form = cls(
                     agency_ein=form['agency_ein'],
                     form_name=form['form_name'],
+                    form_description=form['form_description'],
                     field_definitions=form['field_definitions'],
                     repeatable=form['repeatable'],
                     category=form['category']

--- a/app/templates/custom_request_form_templates/form_description_template.html
+++ b/app/templates/custom_request_form_templates/form_description_template.html
@@ -1,0 +1,3 @@
+<div class="custom-request-form-description">
+    <p>{{ form_description }}</p>
+</div>

--- a/data/custom_request_forms.json
+++ b/data/custom_request_forms.json
@@ -3,6 +3,7 @@
     {
       "agency_ein": "0056",
       "form_name": "Arrest Report",
+      "form_description": "Form for requesting an arrest report",
       "field_definitions": [
         {
           "Arrest Report #": {
@@ -60,6 +61,7 @@
     {
       "agency_ein": "0056",
       "form_name": "Complaint Report",
+      "form_description": "Form for requesting a complaint report",
       "field_definitions": [
         {
           "Complaint Report #": {
@@ -117,6 +119,7 @@
     {
       "agency_ein": "0056",
       "form_name": "Body Worn Camera Video",
+      "form_description": "Form for requesting body worn camera footage",
       "field_definitions": [
         {
           "Date of Incident": {
@@ -195,6 +198,7 @@
     {
       "agency_ein": "0056",
       "form_name": "NYPD Test Form",
+      "form_description": "",
       "field_definitions": [
         {
           "Input Test": {

--- a/migrations/versions/7e0434686370_added_custom_request_forms_table.py
+++ b/migrations/versions/7e0434686370_added_custom_request_forms_table.py
@@ -20,6 +20,7 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('agency_ein', sa.String(length=4), nullable=False),
     sa.Column('form_name', sa.String(), nullable=False),
+    sa.Column('form_description', sa.String(), nullable=False),
     sa.Column('field_definitions', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
     sa.Column('repeatable', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['agency_ein'], ['agencies.ein'], ),


### PR DESCRIPTION
This PR adds a new column in `CustomRequestForms` for `form_description`. If no description is needed for the form you can leave the `form_description` key in `custom_request_forms.json` as a blank string. You can use markdown in `form_description`.

If your database already has the custom request forms table please run the following commands:
`python manage.py db downgrade 445e50628f6b`
`python manage.py db upgrade dc926c74551d`

I made changes to an existing migration instead of creating a new one in order to keep a more logical order to the columns without dropping and creating a new table.