### PR TITLE
Feature/OP-1221: Add Notes after Closing

### DIFF
--- a/app/templates/request/view_request.html
+++ b/app/templates/request/view_request.html
@@ -112,9 +112,13 @@
                                 {% if permissions['re_open'] %}
                                     <li class="active"><a href="#reopen-request" data-toggle="tab">Re-Open</a></li>
                                 {% endif %}
+                                {% if permissions['add_note'] %}
+                                    <li><a href="#add-note" data-toggle="tab">Add Note</a></li>
+                                {% endif %}
                                 {% if generate_letters_enabled and permissions['generate_letter'] %}
                                     <li><a href="#generate-envelope" data-toggle="tab">Generate Envelope</a></li>
                                 {% endif %}
+
                             {% endif %}
                         </ul>
                         <div class="tab-content content-min-height">
@@ -222,10 +226,15 @@
                                         {% include "response/add_reopening.html" %}
                                     </div>
                                 {% endif %}
+                                {% if permissions['add_note'] %}
+                                    <div class="tab-pane" id="add-note">
+                                        {% include "response/add_note.html" %}
+                                    </div>
+                                {% endif %}
                                 {% if generate_letters_enabled and permissions['generate_letter'] %}
-                                        <div class="tab-pane" id="generate-envelope">
-                                            {% include "response/generate_envelope.html" %}
-                                        </div>
+                                    <div class="tab-pane" id="generate-envelope">
+                                        {% include "response/generate_envelope.html" %}
+                                    </div>
                                 {% endif %}
                             {% endif %}
                         </div>

--- a/app/templates/request/view_request.html
+++ b/app/templates/request/view_request.html
@@ -112,7 +112,7 @@
                                 {% if permissions['re_open'] %}
                                     <li class="active"><a href="#reopen-request" data-toggle="tab">Re-Open</a></li>
                                 {% endif %}
-                                {% if permissions['add_note'] %}
+                                {% if permissions['add_note'] and current_user.is_agency%}
                                     <li><a href="#add-note" data-toggle="tab">Add Note</a></li>
                                 {% endif %}
                                 {% if generate_letters_enabled and permissions['generate_letter'] %}
@@ -226,7 +226,7 @@
                                         {% include "response/add_reopening.html" %}
                                     </div>
                                 {% endif %}
-                                {% if permissions['add_note'] %}
+                                {% if permissions['add_note'] and current_user.is_agency %}
                                     <div class="tab-pane" id="add-note">
                                         {% include "response/add_note.html" %}
                                     </div>

--- a/app/templates/response/add_note.html
+++ b/app/templates/response/add_note.html
@@ -21,7 +21,7 @@
                               maxlength="5000"></textarea>
                     <h5 id="note-content-character-count">5000 characters remaining</h5>
                     {% if current_user.is_agency %}
-                        {% if permissions['edit_note_privacy'] %}
+                        {% if permissions['edit_note_privacy'] and request.status != status.CLOSED %}
                             <div class="radio">
                                 <label>
                                     <input type="radio" class="note-privacy" name="privacy" value="release_public">Release


### PR DESCRIPTION
Agency users with the `add_note` permission now have the ability to add notes after a request has been closed.

These notes will only be private.