### PR TITLE
bugfix/OP-998: Alert should be Modal when uploading duplicate file

### DIFF
--- a/app/static/js/upload/fileupload.js
+++ b/app/static/js/upload/fileupload.js
@@ -2,16 +2,19 @@
 
 function bindFileUpload(target,
                         request_id,
+                        duplicateFileModal,
                         for_update,
                         response_id,
                         uploadTemplateId,
                         downloadTemplateId,
-                        nextButton) {
+                        nextButton
+                        ) {
     /*
     Binds jquery file upload to the element identified by 'target'
 
     @param {string} target - jquery selector string (ex. "#fileupload")
     @param {string} request_id - FOIL request id
+    @param {selector} duplicateFileModal - jQuery selector for duplicate file alert modal
     @param {bool} for_update - editing a file?
     @param {int} response_id - response id of file being replaced
     @param {string} uploadTemplateId - jquery file upload uploadTemplateId
@@ -103,7 +106,9 @@ function bindFileUpload(target,
             });
             data.files = $.map(data.files, function (file, i) {
                 if ($.inArray(file.name, currentFiles) >= 0) {
-                    alert("The file '" + file.name + "' has already been added.");
+                    var modalBody = $(duplicateFileModal).find(".modal-body");
+                    modalBody.html("<p>The file '" + file.name + "' has already been added.");
+                    $(duplicateFileModal).modal('show');
                     return null;
                 }
                 return file;

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -180,3 +180,16 @@ input[type="radio"], input[type="checkbox"] {
     /* inline-block space fix */
     margin-right: -4px;
 }
+
+.vertical-alignment-helper {
+    display:table;
+    height: 100%;
+    width: 100%;
+    pointer-events:none; /* This makes sure that we can still click outside of the modal to close it */
+}
+.vertical-align-center {
+    /* To center vertically */
+    display: table-cell;
+    vertical-align: middle;
+    pointer-events:none;
+}

--- a/app/static/styles/new_request/new-request.css
+++ b/app/static/styles/new_request/new-request.css
@@ -87,18 +87,7 @@
     margin-right: auto;
 }
 
-.vertical-alignment-helper {
-    display:table;
-    height: 100%;
-    width: 100%;
-    pointer-events:none; /* This makes sure that we can still click outside of the modal to close it */
-}
-.vertical-align-center {
-    /* To center vertically */
-    display: table-cell;
-    vertical-align: middle;
-    pointer-events:none;
-}
+
 .modal-content {
     /* Bootstrap sets the size of the modal in the modal-dialog class, we need to inherit it */
     width:inherit;

--- a/app/templates/request/fileupload_add_file.js.html
+++ b/app/templates/request/fileupload_add_file.js.html
@@ -2,5 +2,5 @@
     "use strict";
 
     /* For Add File */
-    bindFileUpload('#fileupload', "{{ request.id }}");
+    bindFileUpload('#fileupload', "{{ request.id }}", '#duplicate-file-modal');
 </script>

--- a/app/templates/response/add_file.html
+++ b/app/templates/response/add_file.html
@@ -4,6 +4,23 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
     <div class="col-sm-9">
+        <div class="modal fade" id="duplicate-file-modal" tabindex="-1" role="dialog">
+            <div class="vertical-alignment-helper">
+                <div class="modal-dialog vertical-align-center">
+                    <div class="modal-content col-sm-4 col-sm-offset-4">
+                        <div class="modal-header">
+                            <h4 class="modal-title">Duplicate File Added</h4>
+                        </div>
+                        <div class="modal-body">Are you sure you want to delete this form? All your entered information
+                            will be lost.
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div class="fileupload-control">
             <fieldset>
                 <legend>
@@ -80,20 +97,6 @@
         </div>
     </div>
 </form>
-<div class="modal fade" id="duplicate-file-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                Duplicate File Added
-            </div>
-            <div class="modal-body">
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
 
 {% raw %}
 <!-- The template to display files available for upload -->
@@ -126,6 +129,10 @@
             </div>
         </div>
     {% } %}
+
+
+
+
 
 
 </script>
@@ -196,6 +203,10 @@
     {% } %}
 
 
+
+
+
+
     </script>
     {% endraw %}
 {% else %}
@@ -253,6 +264,10 @@
             </div>
         </div>
     {% } %}
+
+
+
+
 
 
     </script>

--- a/app/templates/response/add_file.html
+++ b/app/templates/response/add_file.html
@@ -129,12 +129,6 @@
             </div>
         </div>
     {% } %}
-
-
-
-
-
-
 </script>
 {% endraw %}
 <!-- The template to display files after upload -->
@@ -201,12 +195,6 @@
             </div>
         </div>
     {% } %}
-
-
-
-
-
-
     </script>
     {% endraw %}
 {% else %}
@@ -264,12 +252,6 @@
             </div>
         </div>
     {% } %}
-
-
-
-
-
-
     </script>
     {% endraw %}
 {% endif %}

--- a/app/templates/response/add_file.html
+++ b/app/templates/response/add_file.html
@@ -1,28 +1,28 @@
 <form id="fileupload" class="fileupload-form" action="/response/file/{{ request.id }}" method="POST"
       enctype="multipart/form-data">
 
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
     <div class="col-sm-9">
         <div class="fileupload-control">
             <fieldset>
-            <legend>
-                Add File
-                <small data-toggle="popover" data-placement="right" data-trigger="hover" title="Adding Files"
-                       data-content="This function allows you to upload multiple files for a single request.">
-                    <span class="glyphicon glyphicon-question-sign"></span>
-                </small>
-            </legend>
-            <div class="first">
-                <div class="fileupload-error-messages alert alert-danger" hidden></div>
-                <!-- first div of the add-file form containing uploads -->
-                <div class="row fileupload-buttonbar">
-                    <div class="col-lg-7">
-                        <label class="btn btn-success fileinput-button">
-                            <i class="glyphicon glyphicon-plus"></i>
-                            <span>Add files...</span>
-                            <input type="file" name="file" id="add-files" multiple>
-                        </label>
+                <legend>
+                    Add File
+                    <small data-toggle="popover" data-placement="right" data-trigger="hover" title="Adding Files"
+                           data-content="This function allows you to upload multiple files for a single request.">
+                        <span class="glyphicon glyphicon-question-sign"></span>
+                    </small>
+                </legend>
+                <div class="first">
+                    <div class="fileupload-error-messages alert alert-danger" hidden></div>
+                    <!-- first div of the add-file form containing uploads -->
+                    <div class="row fileupload-buttonbar">
+                        <div class="col-lg-7">
+                            <label class="btn btn-success fileinput-button">
+                                <i class="glyphicon glyphicon-plus"></i>
+                                <span>Add files...</span>
+                                <input type="file" name="file" id="add-files" multiple>
+                            </label>
                             <button type="submit" class="btn btn-primary start">
                                 <i class="glyphicon glyphicon-upload"></i>
                                 <span>Start All</span>
@@ -80,6 +80,20 @@
         </div>
     </div>
 </form>
+<div class="modal fade" id="duplicate-file-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                Duplicate File Added
+            </div>
+            <div class="modal-body">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 {% raw %}
 <!-- The template to display files available for upload -->
@@ -112,6 +126,7 @@
             </div>
         </div>
     {% } %}
+
 
 </script>
 {% endraw %}
@@ -180,6 +195,7 @@
         </div>
     {% } %}
 
+
     </script>
     {% endraw %}
 {% else %}
@@ -237,6 +253,7 @@
             </div>
         </div>
     {% } %}
+
 
     </script>
     {% endraw %}


### PR DESCRIPTION
Alert box should be replaced with a modal dialog when uploading duplicate file(s) so that the message is always centered on the screen.

Acceptance Criteria:
- Modal dialog should appear for the file that is a duplicate for the current upload session.

Estimates:
Development: 2h
Code Review: 1h
QA: 1h

