### PR TITLE
Feature/OP-1438: Fixed sorting for forms/fields greater than 10

### DIFF
--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -497,10 +497,18 @@ function processCustomRequestFormData() {
     for (var i = 0; i < currentValues.length; i++) {
         if (currentValues[i] !== "") {
             var target = (i + 1).toString();
-            var formKey = "form_" + formNumber;
-            var fieldKey = "field_" + fieldNumber;
+            var formKey = "form_";
+            var fieldKey = "field_";
             var formName = $("#request-type-" + target + " option:selected").text();
             var previousRadioId = "";
+
+            // add leading zero to forms less than 10 so they can be properly sorted
+            if (formNumber < 10) {
+                formKey = formKey + "0" + formNumber;
+            }
+            else {
+                formKey = formKey + formNumber;
+            }
 
             customRequestFormData[formKey] = {};
             customRequestFormData[formKey]["form_name"] = formName;
@@ -509,6 +517,13 @@ function processCustomRequestFormData() {
             // loop through each form field to get the value
             $("#custom-request-form-content-" + target + " > .custom-request-form-field > .custom-request-form-data").each(function () {
                 var fieldName = $("label[for='" + this.id + "']").html();
+                // add leading zero to fields less than 10 so they can be properly sorted
+                if (fieldNumber < 10) {
+                    fieldKey = fieldKey + "0" + fieldNumber;
+                }
+                else {
+                    fieldKey = fieldKey + fieldNumber;
+                }
                 customRequestFormData[formKey]["form_fields"][fieldKey] = {};
                 customRequestFormData[formKey]["form_fields"][fieldKey]["field_name"] = fieldName;
 
@@ -531,7 +546,7 @@ function processCustomRequestFormData() {
                     customRequestFormData[formKey]["form_fields"][fieldKey]["field_value"] = this.value;
                 }
                 fieldNumber++;
-                fieldKey = "field_" + fieldNumber;
+                fieldKey = "field_";
             });
             formNumber++;
             fieldNumber = 1;


### PR DESCRIPTION
QA found a bug where if you had more than 10 forms they would show out of order in the request page. This is because the jinja `dictsort` function sorts alphabetically so it was sorting as:

`form_1, form_10, form_11, form_12, form_2, form_3, ...etc`

Fixed this by adding a leading 0 to forms/fields that were less than 10 so it will look like:

`form_01, form_02, form_03,..., form_10, form_11, form_12` 