### PR TITLE
Bugfix/OP-1516: Responses section values disappear after editing response

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1235,7 +1235,13 @@ class Responses(db.Model):
 
     @property
     def event_timestamp(self):
-        return Events.query.filter_by(response_id=self.id).one().timestamp
+        """
+        This function runs a query on the Events table to get all associated event rows for a response and returns
+        the newest timestamp of the newest event which will be displayed on the frontend.
+        :return: timestamp of the newest event row associated with a response
+        """
+        timestamps = Events.query.filter_by(response_id=self.id).order_by(desc(Events.timestamp)).all()
+        return timestamps[0].timestamp
 
     def make_public(self):
         self.privacy = response_privacy.RELEASE_AND_PUBLIC


### PR DESCRIPTION
This PR fixes a bug where the response rows disappear if you edit a response.

This bug occurs because we changed the response rows to order by event timestamps instead of response date_modified to preserve proper ordering on the front end. There is a query to get the event row associated with that response_id. Since editing a note (or any response) will create another event row with the same response_id, the query fails because it is expecting one row but multiple rows are returned back.

The fix is to query using .all() instead of .one() and take the newest of the list of events and use that to display on the frontend.