### PR TITLE
Feature/OP-1501: Add Tooltips, Placeholders, Popovers, and Character Counters to Field Templates

### DIFF
--- a/app/agency/api/views.py
+++ b/app/agency/api/views.py
@@ -109,6 +109,8 @@ def get_custom_request_form_fields():
 
     form_template = render_template('custom_request_form_templates/form_description_template.html',
                                     form_description=custom_request_form.form_description)
+    data = {}
+    character_counters = {}
     for field in custom_request_form.field_definitions:
         for key, value in field.items():
             field_text = key
@@ -119,9 +121,19 @@ def get_custom_request_form_fields():
             field_required = value['required']
             min_length = value.get('min_length', None)
             max_length = value.get('max_length', None)
+            character_counter = value.get('character_counter', None)
+            placeholder = value.get('placeholder', None)
+
+            if max_length and character_counter:
+                # add to character_counters so they can be later initialized
+                character_counter_key = field_name + "-" + str(instance_id)
+                character_counters[character_counter_key] = max_length
 
             form_template = form_template + render_template(
                 'custom_request_form_templates/{}_template.html'.format(field_type), field_text=field_text,
                 field_name=field_name, field_info=field_info, options=field_values, field_required=field_required,
-                min_length=min_length, max_length=max_length, instance_id=instance_id) + '\n'
-    return jsonify(form_template), 200
+                min_length=min_length, max_length=max_length, instance_id=instance_id, placeholder=placeholder,
+                character_counter=character_counter) + '\n'
+    data["form_template"] = form_template
+    data["character_counters"] = character_counters
+    return jsonify(data), 200

--- a/app/agency/api/views.py
+++ b/app/agency/api/views.py
@@ -111,6 +111,8 @@ def get_custom_request_form_fields():
                                     form_description=custom_request_form.form_description)
     data = {}
     character_counters = {}
+    popovers = {}
+    tooltips = {}
     for field in custom_request_form.field_definitions:
         for key, value in field.items():
             field_text = key
@@ -123,17 +125,29 @@ def get_custom_request_form_fields():
             max_length = value.get('max_length', None)
             character_counter = value.get('character_counter', None)
             placeholder = value.get('placeholder', None)
+            popover = value.get('popover', None)
+            tooltip = value.get('tooltip', None)
 
             if max_length and character_counter:
                 # add to character_counters so they can be later initialized
-                character_counter_key = field_name + "-" + str(instance_id)
-                character_counters[character_counter_key] = max_length
+                character_counter_id = field_name + "-" + str(instance_id)
+                character_counters[character_counter_id] = max_length
+
+            if popover:
+                popover_id = field_name + '-' + str(instance_id)
+                popovers[popover_id] = popover
+
+            if tooltip:
+                tooltip_id = field_name + '-' + str(instance_id)
+                tooltips[tooltip_id] = tooltip
 
             form_template = form_template + render_template(
                 'custom_request_form_templates/{}_template.html'.format(field_type), field_text=field_text,
                 field_name=field_name, field_info=field_info, options=field_values, field_required=field_required,
                 min_length=min_length, max_length=max_length, instance_id=instance_id, placeholder=placeholder,
-                character_counter=character_counter) + '\n'
-    data["form_template"] = form_template
-    data["character_counters"] = character_counters
+                character_counter=character_counter, tooltip=tooltip) + '\n'
+    data['form_template'] = form_template
+    data['character_counters'] = character_counters
+    data['popovers'] = popovers
+    data['tooltips'] = tooltips
     return jsonify(data), 200

--- a/app/agency/api/views.py
+++ b/app/agency/api/views.py
@@ -125,10 +125,10 @@ def get_custom_request_form_fields():
             popover = value.get('popover', None)
             tooltip = value.get('tooltip', None)
 
-            if max_length and character_counter:
-                # add to character_counters so they can be later initialized
+            if character_counter:
                 character_counter_id = field_name + "-" + str(instance_id)
-                character_counters[character_counter_id] = max_length
+                character_counters[character_counter_id] = {"min_length": min_length,
+                                                            "max_length": max_length}
 
             if popover:
                 popover_id = field_name + '-' + str(instance_id)

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -525,6 +525,30 @@ function renderCustomRequestForm(target) {
                     );
                 }
 
+                // initialize popovers in custom forms
+                for (var id in data["popovers"]) {
+                    $("#" + id).attr({
+                        'data-placement': "top",
+                        'data-trigger': "hover focus",
+                        'data-toggle': "popover",
+                        'data-content': data["popovers"][id]["content"],
+                        title: data["popovers"][id]["title"]
+                    });
+                    $("#" + id).popover();
+                }
+
+                // initialize tooltips in custom forms
+                for (var id in data["popovers"]) {
+                    $("#" + id + "-tooltip").attr({
+                        'data-placement': "right",
+                        'data-trigger': "hover focus",
+                        'data-toggle': "popover",
+                        'data-content': data["tooltips"][id]["content"],
+                        title: data["tooltips"][id]["title"]
+                    });
+                    $("#" + id + "-tooltip").popover();
+                }
+
                 // Do not reset on click
                 $(".select-multiple").find("option").mousedown(function (e) {
                     e.preventDefault();

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -538,7 +538,7 @@ function renderCustomRequestForm(target) {
                 }
 
                 // initialize tooltips in custom forms
-                for (var id in data["popovers"]) {
+                for (var id in data["tooltips"]) {
                     $("#" + id + "-tooltip").attr({
                         'data-placement': "right",
                         'data-trigger': "hover focus",

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -481,7 +481,7 @@ function renderCustomRequestForm(target) {
                     // render timepicker plugins
                     $(".timepicker").timepicker({
                         timeFormat: "h:mm p",
-                        interval: 30,
+                        interval: 15,
                         minTime: "12:00am",
                         maxTime: "11:59pm",
                         startTime: "12:00am",

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -405,7 +405,6 @@ function updateCustomRequestFormDropdowns() {
         var requestTypeOptions = "#" + this.id + " > option";
         if (this.value !== "") { // if the dropdown is not exmpty execute this block
             $(requestTypeOptions).each(function () { // loop through each option in the dropdown
-                console.log(this.text);
                 if (this.text !== "" && this.text !== categoryDividerText) { // only update options that actually have text
                     var originalText = originalFormNames[this.value]; // get the actual form name
                     if (backwards[this.value] === 0) { // if there are no instances of the form keep the text at 0

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -16,12 +16,12 @@ $(function () {
     });
 });
 
-function characterCounter(target, limit, currentLength, minLength) {
+function characterCounter(target, maxLength, currentLength, minLength) {
     /* Global character counter
      *
      * Parameters:
      * - target: string of target selector
-     * - limit: integer of maximum character length
+     * - maxLength: integer of maximum character length
      * - currentLength: integer value of keyed in content
      * - minLength: integer of minimum character length (default = 0)
      *
@@ -34,7 +34,7 @@ function characterCounter(target, limit, currentLength, minLength) {
      * }
      *
      * */
-    var length = limit - currentLength;
+    var length = maxLength - currentLength;
     minLength = (typeof minLength !== "undefined") ? minLength : 0;
     var s = length === 1 ? "" : "s";
     $(target).text(length + " character" + s + " remaining");
@@ -48,12 +48,12 @@ function characterCounter(target, limit, currentLength, minLength) {
     }
 }
 
-function generate_character_counter_handler(id, length) {
+function generate_character_counter_handler(id, maxLength, minLength) {
     /*
      * This function creates character counter handlers for when you have multiple events inside a loop
      */
     return function () {
-        characterCounter("#" + id + "-character-count", length, $(this).val().length);
+        characterCounter("#" + id + "-character-count", maxLength, $(this).val().length, minLength);
     };
 }
 
@@ -556,7 +556,7 @@ function renderCustomRequestForm(target) {
                 // initialize character counters in custom forms
                 for (var id in data["character_counters"]) {
                     $("#" + id).keyup(
-                        generate_character_counter_handler(id, data["character_counters"][id])
+                        generate_character_counter_handler(id, data["character_counters"][id]["max_length"], data["character_counters"][id]["min_length"])
                     );
                 }
 

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -738,7 +738,8 @@ function processCustomRequestFormData() {
             var target = (i + 1).toString();
             var formKey = "form_";
             var fieldKey = "field_";
-            var formName = $("#request-type-" + target + " option:selected").text();
+            var formId = $("#request-type-" + target + " option:selected").val();
+            var formName = originalFormNames[formId];
             var previousRadioId = "";
             var completedFields = 0;
 

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -48,6 +48,15 @@ function characterCounter(target, limit, currentLength, minLength) {
     }
 }
 
+function generate_character_counter_handler(id, length) {
+    /*
+     * This function creates character counter handlers for when you have multiple events inside a loop
+     */
+    return function () {
+        characterCounter("#" + id + "-character-count", length, $(this).val().length);
+    };
+}
+
 function regexUrlChecker(value) {
     /* Global regexUrlChecker
      *
@@ -430,7 +439,7 @@ function renderCustomRequestForm(target) {
 
                 detectChange(); // determine which request type dropdown was changed
 
-                customRequestFormContent.html(data);
+                customRequestFormContent.html(data["form_template"]);
                 previousValues[target - 1] = formId;
                 updateCustomRequestFormDropdowns();
                 if (categorized) {
@@ -472,7 +481,7 @@ function renderCustomRequestForm(target) {
                     // render timepicker plugins
                     $(".timepicker").timepicker({
                         timeFormat: "h:mm p",
-                        interval: 1,
+                        interval: 30,
                         minTime: "12:00am",
                         maxTime: "11:59pm",
                         startTime: "12:00am",
@@ -507,6 +516,13 @@ function renderCustomRequestForm(target) {
                 catch (err) {
                     // if one of the forms doesn't have a time field it will throw an error when you try to render it
                     // TODO: find a better way to handle this error
+                }
+
+                // initialize character counters in custom forms
+                for (var id in data["character_counters"]) {
+                    $("#" + id).keyup(
+                        generate_character_counter_handler(id, data["character_counters"][id])
+                    );
                 }
 
                 // Do not reset on click

--- a/app/templates/custom_request_form_templates/date_template.html
+++ b/app/templates/custom_request_form_templates/date_template.html
@@ -1,4 +1,8 @@
 <div class="custom-request-form-date custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label><br>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    {% if tooltip %}
+        <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
+    {% endif %}
+    <br>
     <input class="input-block-level custom-request-form-datepicker custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" type="text" name="{{ field_name }}-{{ instance_id }}" maxlength="10" {% if field_required %}data-parsley-required{% endif %} placeholder="MM/DD/YYYY"><br>
 </div>

--- a/app/templates/custom_request_form_templates/input_template.html
+++ b/app/templates/custom_request_form_templates/input_template.html
@@ -3,5 +3,10 @@
     <input class="input-block-level custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" type="text" name="{{ field_name }}-{{ instance_id }}"
            {% if field_required %}data-parsley-required{% endif %}
            {% if max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"{% endif %}
-           {% if min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"{% endif %}><br>
+           {% if min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"{% endif %}
+           {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}>
+    {% if max_length and character_counter %}
+        <h5 id="{{ field_name }}-{{ instance_id }}-character-count">{{ max_length }} characters remaining</h5>
+    {% endif %}
+    <br>
 </div>

--- a/app/templates/custom_request_form_templates/input_template.html
+++ b/app/templates/custom_request_form_templates/input_template.html
@@ -6,8 +6,10 @@
     <br>
     <input class="input-block-level custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" type="text" name="{{ field_name }}-{{ instance_id }}"
            {% if field_required %}data-parsley-required{% endif %}
-           {% if max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"{% endif %}
-           {% if min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"{% endif %}
+           {% if max_length and min_length %}maxlength="{{ max_length }}" minlength="{{ min_length }}"
+           {% elif max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"
+           {% elif min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"
+           {% endif %}
            {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}>
     {% if max_length and character_counter %}
         <h5 id="{{ field_name }}-{{ instance_id }}-character-count">{{ max_length }} characters remaining</h5>

--- a/app/templates/custom_request_form_templates/input_template.html
+++ b/app/templates/custom_request_form_templates/input_template.html
@@ -1,5 +1,9 @@
 <div class="custom-request-form-input custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label><br>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    {% if tooltip %}
+        <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
+    {% endif %}
+    <br>
     <input class="input-block-level custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" type="text" name="{{ field_name }}-{{ instance_id }}"
            {% if field_required %}data-parsley-required{% endif %}
            {% if max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"{% endif %}

--- a/app/templates/custom_request_form_templates/radio_template.html
+++ b/app/templates/custom_request_form_templates/radio_template.html
@@ -1,5 +1,9 @@
 <div class="custom-request-form-radio custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label><br>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    {% if tooltip %}
+        <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
+    {% endif %}
+    <br>
     <h5 style="margin-top: 0;">{{ field_info }}</h5>
     {% for option in options %}
         <input class="custom-request-form-data" type="radio" id="{{ field_name }}-{{ instance_id }}" name="{{ field_name }}-{{ instance_id }}" value="{{ option }}" style="display: inline;"/>&nbsp;{{ option }}<br>

--- a/app/templates/custom_request_form_templates/select_dropdown_template.html
+++ b/app/templates/custom_request_form_templates/select_dropdown_template.html
@@ -1,5 +1,9 @@
 <div class="custom-request-form-select-dropdown custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label><br>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    {% if tooltip %}
+        <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
+    {% endif %}
+    <br>
     <select class="input-block-level custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" name="{{ field_name }}-{{ instance_id }}" {% if field_required %}data-parsley-required{% endif %}>
         <option value=""></option>
         {% for option in options %}

--- a/app/templates/custom_request_form_templates/select_multiple_template.html
+++ b/app/templates/custom_request_form_templates/select_multiple_template.html
@@ -1,5 +1,9 @@
 <div class="custom-request-form-select-multiple custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label><br>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    {% if tooltip %}
+        <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
+    {% endif %}
+    <br>
     <select class="form-control select-multiple custom-request-form-data" multiple size="5" id="{{ field_name }}-{{ instance_id }}" name="{{ field_name }}-{{ instance_id }}" {% if field_required %}data-parsley-required{% endif %}>
         {% for option in options %}
             <option value="{{ option }}">{{ option }}</option>

--- a/app/templates/custom_request_form_templates/textarea_template.html
+++ b/app/templates/custom_request_form_templates/textarea_template.html
@@ -1,5 +1,9 @@
 <div class="custom-request-form-textarea custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label><br>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    {% if tooltip %}
+        <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
+    {% endif %}
+    <br>
     <textarea class="input-block-level custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" name="{{ field_name }}-{{ instance_id }}" style="height: 10rem;"
               {% if field_required %}data-parsley-required{% endif %}
               {% if max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"{% endif %}

--- a/app/templates/custom_request_form_templates/textarea_template.html
+++ b/app/templates/custom_request_form_templates/textarea_template.html
@@ -6,8 +6,10 @@
     <br>
     <textarea class="input-block-level custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" name="{{ field_name }}-{{ instance_id }}" style="height: 10rem;"
               {% if field_required %}data-parsley-required{% endif %}
-              {% if max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"{% endif %}
-              {% if min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"{% endif %}
+              {% if max_length and min_length %}maxlength="{{ max_length }}" minlength="{{ min_length }}"
+              {% elif max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"
+              {% elif min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"
+              {% endif %}
               {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}></textarea>
     {% if max_length and character_counter %}
         <h5 id="{{ field_name }}-{{ instance_id }}-character-count">{{ max_length }} characters remaining</h5>

--- a/app/templates/custom_request_form_templates/textarea_template.html
+++ b/app/templates/custom_request_form_templates/textarea_template.html
@@ -3,5 +3,10 @@
     <textarea class="input-block-level custom-request-form-data" id="{{ field_name }}-{{ instance_id }}" name="{{ field_name }}-{{ instance_id }}" style="height: 10rem;"
               {% if field_required %}data-parsley-required{% endif %}
               {% if max_length %}data-parsley-maxlength="{{ max_length }}" maxlength="{{ max_length }}"{% endif %}
-              {% if min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"{% endif %}></textarea><br>
+              {% if min_length %}data-parsley-minlength="{{ min_length }}" minlength="{{ min_length }}"{% endif %}
+              {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}></textarea>
+    {% if max_length and character_counter %}
+        <h5 id="{{ field_name }}-{{ instance_id }}-character-count">{{ max_length }} characters remaining</h5>
+    {% endif %}
+    <br>
 </div>

--- a/app/templates/custom_request_form_templates/time_template.html
+++ b/app/templates/custom_request_form_templates/time_template.html
@@ -1,4 +1,8 @@
 <div class="custom-request-form-time custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label><br>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    {% if tooltip %}
+        <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
+    {% endif %}
+    <br>
     <input class="input-block-level timepicker custom-request-form-data" type="text" id="{{ field_name }}-{{ instance_id }}" name="{{ field_name }}-{{ instance_id }}" maxlength="9" {% if field_required %}data-parsley-required{% endif %} placeholder="12:00 AM"><br>
 </div>

--- a/data/custom_request_forms.json
+++ b/data/custom_request_forms.json
@@ -12,7 +12,15 @@
             "required": false,
             "placeholder": "123456789",
             "max_length": "50",
-            "character_counter": true
+            "character_counter": true,
+            "popover": {
+              "title": "Arrest report number title",
+              "content": "Arrest report number content"
+            },
+            "tooltip": {
+              "title": "Arrest report number tooltip title",
+              "content": "Arrest report number tooltip content"
+            }
           }
         },
         {
@@ -21,7 +29,15 @@
             "name": "precinct-number",
             "required": false,
             "max_length": "10",
-            "character_counter": true
+            "character_counter": true,
+            "popover": {
+              "title": "Precinct number title",
+              "content": "Precinct number content"
+            },
+            "tooltip": {
+              "title": "Precinct number tooltip title",
+              "content": "Precinct number tooltip content"
+            }
           }
         },
         {

--- a/data/custom_request_forms.json
+++ b/data/custom_request_forms.json
@@ -9,21 +9,28 @@
           "Arrest Report #": {
             "type": "input",
             "name": "arrest-report-number",
-            "required": false
+            "required": false,
+            "placeholder": "123456789",
+            "max_length": "50",
+            "character_counter": true
           }
         },
         {
           "Precinct #": {
             "type": "input",
             "name": "precinct-number",
-            "required": false
+            "required": false,
+            "max_length": "10",
+            "character_counter": true
           }
         },
         {
           "Name": {
             "type": "input",
             "name": "arrest-report-name",
-            "required": false
+            "required": false,
+            "max_length": "20",
+            "character_counter": true
           }
         },
         {
@@ -214,7 +221,9 @@
           "Textarea Test": {
             "type": "textarea",
             "name": "textarea-test",
-            "required": false
+            "required": false,
+            "max_length": "50",
+            "character_counter": true
           }
         },
         {


### PR DESCRIPTION
This PR adds tooltips, placeholders, popovers, and character counters to custom request form fields.

To add a tooltip add the following property to a field definition in the `custom_request_forms.json`:
`"tooltip": {
  "title": "Sample tooltip title",
  "content": "Sample tooltip content"
}`

To add a popover to any field except `radio` add the following property:
`"popover": {
  "title": "Sample popover title",
  "content": "Sample popover content"
}`

To add placeholder text to input and textarea fields add the following property:
`"placeholder": "Sample placeholder text"`

To add character counters to input and text area fields add the following property:
`"character_counter": true`
Character counters are tied to value in the `max_length` property