### PR TITLE
bugfix/OP-1532: Add CLI flag for updating Events table

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -97,7 +97,7 @@ def _update_request_statuses():
                         user_guid=None,
                         auth_user_type=None,
                         type_=REQ_STATUS_CHANGED,
-                        previous_value={"request": request.status},
+                        previous_value={"status": request.status},
                         new_value={"status": request_status.OVERDUE},
                         response_id=None,
                     )

--- a/manage.py
+++ b/manage.py
@@ -1,10 +1,7 @@
 # manage.py
-import ast
 import sys
 import os
-import csv
-# import subprocess
-from tempfile import NamedTemporaryFile
+from datetime import timedelta
 
 from flask_migrate import Migrate, MigrateCommand
 from flask_script import Manager, Shell
@@ -26,40 +23,26 @@ from app.models import (
     LetterTemplates,
     Envelopes,
     EnvelopeTemplates,
-    CustomRequestForms
+    CustomRequestForms,
+    Determinations,
 )
-from app.request.utils import (
-    generate_guid
-)
-from app.constants import user_type_auth
+from app.request.utils import generate_guid
+from app.constants import user_type_auth, event_type, request_status, determination_type
 from app.lib.user_information import create_mailing_address
 
 COV = None
-if os.environ.get('FLASK_COVERAGE'):
+if os.environ.get("FLASK_COVERAGE"):
     import coverage
 
-    COV = coverage.coverage(branch=True, include='app/*',
-                            config_file=os.path.join(os.curdir, '.coveragerc'))
+    COV = coverage.coverage(
+        branch=True, include="app/*", config_file=os.path.join(os.curdir, ".coveragerc")
+    )
     COV.start()
 
-app = create_app(os.getenv('FLASK_CONFIG') or 'default', jobs_enabled=False)
+app = create_app(os.getenv("FLASK_CONFIG") or "default", jobs_enabled=False)
 manager = Manager(app)
 migrate = Migrate(app, db)
 
-
-#
-# class Celery(Command):
-#     """
-#     Start Celery
-#     """
-#
-#     # TODO: autoreload and background options?
-#     # http://stackoverflow.com/questions/21666229/celery-auto-reload-on-any-changes
-#     # http://docs.celeryproject.org/en/latest/tutorials/daemonizing.html
-#
-#     celery_command = ['celery', 'worker', '-A', 'celery_worker.celery', '--loglevel=info']
-#     def run(self):
-#         subprocess.Popen(['celery', 'worker', '-A', 'celery_worker.celery', '--loglevel=info'])
 
 def make_shell_context():
     return dict(
@@ -79,7 +62,7 @@ def make_shell_context():
         LetterTemplates=LetterTemplates,
         Envelopes=Envelopes,
         EnvelopeTemplates=EnvelopeTemplates,
-        CustomRequestForms=CustomRequestForms
+        CustomRequestForms=CustomRequestForms,
     )
 
 
@@ -87,15 +70,20 @@ manager.add_command("shell", Shell(make_context=make_shell_context))
 manager.add_command("db", MigrateCommand)
 
 
-# manager.add_command("celery", Celery())
-
-@manager.option('-f', '--fname', dest='first_name', default=None)
-@manager.option('-l', '--lname', dest='last_name', default=None)
-@manager.option('-e', '--email', dest='email', default=None)
-@manager.option('-a', '--agency-ein', dest='ein', default=None)
-@manager.option('--is-admin', dest='is_admin', default=False)
-@manager.option('--is-active', dest='is_active', default=False)
-def create_user(first_name=None, last_name=None, email=None, ein=None, is_admin=False, is_active=False):
+@manager.option("-f", "--fname", dest="first_name", default=None)
+@manager.option("-l", "--lname", dest="last_name", default=None)
+@manager.option("-e", "--email", dest="email", default=None)
+@manager.option("-a", "--agency-ein", dest="ein", default=None)
+@manager.option("--is-admin", dest="is_admin", default=False)
+@manager.option("--is-active", dest="is_active", default=False)
+def create_user(
+    first_name=None,
+    last_name=None,
+    email=None,
+    ein=None,
+    is_admin=False,
+    is_active=False,
+):
     """Create an agency user."""
     if first_name is None:
         raise InvalidCommand("First name is required")
@@ -121,7 +109,7 @@ def create_user(first_name=None, last_name=None, email=None, ein=None, is_admin=
         terms_of_use_accepted=True,
         phone_number=None,
         fax_number=None,
-        mailing_address=create_mailing_address(None, None, None, None)
+        mailing_address=create_mailing_address(None, None, None, None),
     )
     db.session.add(user)
 
@@ -131,7 +119,7 @@ def create_user(first_name=None, last_name=None, email=None, ein=None, is_admin=
         agency_ein=ein,
         is_agency_active=is_active,
         is_agency_admin=is_admin,
-        is_primary_agency=True
+        is_primary_agency=True,
     )
     db.session.add(agency_user)
     db.session.commit()
@@ -139,9 +127,18 @@ def create_user(first_name=None, last_name=None, email=None, ein=None, is_admin=
     print(user)
 
 
-@manager.option('-u', '--users', dest='users', action='store_true', default=False, required=False)
-@manager.option('-a', '--agencies', dest='agencies', action='store_true', default=False, required=False)
-@manager.option('-f', '--filename', dest='filename', default=None, required=True)
+@manager.option(
+    "-u", "--users", dest="users", action="store_true", default=False, required=False
+)
+@manager.option(
+    "-a",
+    "--agencies",
+    dest="agencies",
+    action="store_true",
+    default=False,
+    required=False,
+)
+@manager.option("-f", "--filename", dest="filename", default=None, required=True)
 def import_data(users, agencies, filename):
     """Import data from CSV file."""
     if users:
@@ -150,32 +147,43 @@ def import_data(users, agencies, filename):
         Agencies.populate(csv_name=filename)
 
 
-@manager.option("-t", "--test-name", help="Specify tests (file, class, or specific test)", dest='test_name')
-@manager.option("-v", "--verbose", help="Pytest verbose mode (True/False)", dest='verbose')
-@manager.option("-c", "--coverage", help="Run coverage analysis for tests (True/False)", dest='cov')
+@manager.option(
+    "-t",
+    "--test-name",
+    help="Specify tests (file, class, or specific test)",
+    dest="test_name",
+)
+@manager.option(
+    "-v", "--verbose", help="Pytest verbose mode (True/False)", dest="verbose"
+)
+@manager.option(
+    "-c", "--coverage", help="Run coverage analysis for tests (True/False)", dest="cov"
+)
 def test(cov=False, test_name=None, verbose=False):
     """Run the unit tests."""
-    if cov and not os.environ.get('FLASK_COVERAGE'):
+    if cov and not os.environ.get("FLASK_COVERAGE"):
         import sys
-        os.environ['FLASK_COVERAGE'] = '1'
+
+        os.environ["FLASK_COVERAGE"] = "1"
         os.execvp(sys.executable, [sys.executable] + sys.argv)
     import pytest
+
     command = []
 
     if verbose:
-        command.append('-v')
+        command.append("-v")
 
     if test_name:
-        command.append('tests/{test_name}'.format(test_name=test_name))
+        command.append("tests/{test_name}".format(test_name=test_name))
     else:
-        command.append('tests/')
+        command.append("tests/")
 
     pytest.main(command)
 
     if COV:
         COV.stop()
         COV.save()
-        print('Coverage Summary:')
+        print("Coverage Summary:")
         COV.report()
         COV.html_report()
         COV.xml_report()
@@ -185,8 +193,10 @@ def test(cov=False, test_name=None, verbose=False):
 def profile(length=25, profile_dir=None):
     """Start the application under the code profiler."""
     from werkzeug.contrib.profiler import ProfilerMiddleware
-    app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[length],
-                                      profile_dir=profile_dir)
+
+    app.wsgi_app = ProfilerMiddleware(
+        app.wsgi_app, restrictions=[length], profile_dir=profile_dir
+    )
     app.run()
 
 
@@ -200,15 +210,20 @@ def deploy():
     upgrade()
 
     # pre-populate
-    list(map(lambda x: x.populate(), (
-        Roles,
-        Agencies,
-        Reasons,
-        Users,
-        LetterTemplates,
-        EnvelopeTemplates,
-        CustomRequestForms
-    )))
+    list(
+        map(
+            lambda x: x.populate(),
+            (
+                Roles,
+                Agencies,
+                Reasons,
+                Users,
+                LetterTemplates,
+                EnvelopeTemplates,
+                CustomRequestForms,
+            ),
+        )
+    )
 
     es_recreate()
 
@@ -217,223 +232,35 @@ def deploy():
 def es_recreate():
     """Recreate elasticsearch index and request docs."""
     from app.search.utils import recreate
+
     recreate()
 
 
 @manager.command
-def fix_due_dates():  # for "America/New_York"
-    """
-    Forgot to set due date hour to 5:00 PM in migration script before
-    converting to utc. Besides having the incorrect time, this also means
-    certain due dates do not fall on business days.
-    """
-    from app.lib.db_utils import update_object
-    for request in Requests.query.all():
-        update_object(
-            {"due_date": request.due_date.replace(
-                hour=22, minute=00, second=00, microsecond=00)},
-            Requests,
-            request.id)
-
-
-@manager.command
-def migrate_date_closed():
-    r = Requests.query.filter_by(status='Closed').all()
-    for request in r:
-        request.date_closed = request.last_date_closed
-        db.session.add(request)
-
-    db.session.commit()
-
-@manager.command
-def fix_anonymous_requesters():
-    """
-    Ensures there is only one anonymous requester per request by
-    creating a new anonymous requester (User) for every User Requests record with
-    a duplicate anonymous requester guid and updates the User Requests record.
-    The new user will be identical to the existing one with the exception of the guid.
-    """
-    from app.constants import user_type_request
-    from app.request.utils import generate_guid
-    from app.lib.db_utils import create_object, update_object
-
-    guids = db.engine.execute("""
-        SELECT
-          user_requests.user_guid AS "GUID"
-        FROM user_requests
-          JOIN users ON user_requests.user_guid = users.guid AND user_requests.auth_user_type = users.auth_user_type
-        WHERE user_requests.request_user_type = 'requester'
-        GROUP BY user_requests.user_guid
-        HAVING COUNT(user_requests.request_id) > 1;
-    """)
-
-    for guid, in guids:
-        # get all User Requests with dups, excluding the first (since we need to change all but 1)
-        for ur in UserRequests.query.filter_by(
-                user_guid=guid, request_user_type=user_type_request.REQUESTER
-        ).offset(1):
-            user = Users.query.filter_by(
-                guid=guid, auth_user_type=user_type_auth.ANONYMOUS_USER).one()
-            new_guid = generate_guid()
-            print("{} -> {}".format(guid, new_guid))
-            # create new anonymous requester with new guid
-            create_object(
-                Users(
-                    guid=new_guid,
-                    auth_user_type=user_type_auth.ANONYMOUS_USER,
-                    email=user.email,
-                    first_name=user.first_name,
-                    last_name=user.last_name,
-                    title=user.title,
-                    organization=user.organization,
-                    email_validated=False,
-                    terms_of_use_accepted=False,
-                    phone_number=user.phone_number,
-                    fax_number=user.fax_number,
-                    mailing_address=user.mailing_address
-                )
-            )
-            # update user request with new guid
-            update_object(
-                {"user_guid": new_guid},
-                UserRequests,
-                (ur.user_guid, ur.auth_user_type, ur.request_id)
-            )
-
-
-@manager.option('-i', '--input', help='Full path to input csv.', default=None)
-@manager.option('-o', '--output', help='Full path to output csv. File will be overwritten.', default=None)
-def convert_staff_csvs(input=None, output=None):
-    """
-    Convert data from staff.csv to new format to accomodate multi-agency users.
-
-    :param input: Input file path. Must be a valid CSV.
-    :param output: Output file path
-    """
-    if input is None:
-        raise InvalidCommand("Input CSV is required.")
-
-    if output is None:
-        raise InvalidCommand("Output CSV is required.")
-
-    if output == input:
-        with open(input, 'r') as _:
-            _ = _.read()
-            read_file = csv.DictReader(_)
-
-            temp_write_file = NamedTemporaryFile()
-
-            with open(temp_write_file.name, 'w') as temp:
-                for row in read_file:
-                    try:
-                        print(
-                            '"{ein}#{is_active}#{is_admin}#True","{is_super}","{first_name}","{middle_initial}","{last_name}","{email}","{email_validated}","{terms_of_use_accepted}","{phone_number}","{fax_number}"'.format(
-                                ein=row['agency_ein'],
-                                is_active=row['is_agency_active'],
-                                is_admin=row['is_agency_admin'],
-                                is_super=ast.literal_eval(row['is_super']),
-                                first_name=row['first_name'],
-                                middle_initial=row['middle_initial'],
-                                last_name=row['last_name'],
-                                email=row['email'],
-                                email_validated=ast.literal_eval(row['email_validated']),
-                                terms_of_use_accepted=ast.literal_eval(
-                                    row['terms_of_use_accepted']),
-                                phone_number=row['phone_number'],
-                                fax_number=row['fax_number']
-                            ), file=temp_write_file)
-                    except:
-                        sentry.captureException()
-                        continue
-
-
-@manager.command
-def migrate_to_agency_request_summary():
-    """
-    Updates the events table in the database to use 'agency_request_summary' wherever 'agency_description' was used.
-
-    """
-
-    agency_description_types = ['request_agency_description_edited', 'request_agency_description_date_set',
-                                'request_agency_description_privacy_edited']
-
-    for event in Events.query.filter(Events.type.like('%agency_description%')).all():
-        if event.type in agency_description_types:
-            event.type = event.type.replace('description', 'request_summary')
-        previous_value = event.previous_value
-
-        if previous_value:
-            for key in previous_value.keys():
-                if key == 'agency_description':
-                    previous_value['agency_request_summary'] = previous_value[key]
-                    del previous_value[key]
-
-        new_value = event.new_value
-        if new_value:
-            for key in new_value.keys():
-                if key == 'agency_description':
-                    new_value['agency_request_summary'] = new_value[key]
-                    del new_value[key]
-
-        db.session.add(event)
-
-    for request in Requests.query.all():
-        old = request.privacy
-        if 'agency_description' in request.privacy.keys():
-            request.privacy = None
-            request.privacy = {
-                'agency_request_summary': old['agency_description'],
-                'title': old['title']
-            }
-            db.session.add(request)
-
-    db.session.commit()
-
-
-@manager.command
-def migrate_to_agencyusers():
-    """Migrate Users and Agencies to Users + Agencies + AgencyUsers."""
-    users = Users.query.with_entities(Users.guid,
-                                      Users.auth_user_type,
-                                      Users.agency_ein,
-                                      Users.is_agency_admin,
-                                      Users.is_agency_active
-                                      ).filter(Users.auth_user_type == user_type_auth.AGENCY_LDAP_USER).all()
-
-    for user in users:
-        guid, user_type, ein, is_admin, is_active = user
-        agency_user = AgencyUsers(
-            user_guid=guid,
-            auth_user_type=user_type,
-            agency_ein=ein,
-            is_agency_active=is_active,
-            is_agency_admin=is_admin,
-            is_primary_agency=True
-        )
-        db.session.add(agency_user)
-
-    db.session.commit()
-
-
-@manager.command
 def routes():
+    """
+    Generate a list of HTTP routes for the application.
+    """
     from flask import url_for
     from urllib.parse import unquote
+
     output = []
     for rule in app.url_map.iter_rules():
         options = {}
         for arg in rule.arguments:
-            if arg == 'year':
+            if arg == "year":
                 from datetime import datetime
+
                 options[arg] = "{}".format(datetime.now().year)
                 continue
             options[arg] = "[{}]".format(arg)
 
-        methods = ','.join(rule.methods)
+        methods = ",".join(rule.methods)
         url = url_for(rule.endpoint, **options)
         from datetime import datetime
+
         if str(datetime.now().year) in url:
-            url = url.replace(str(datetime.now().year), '[year]')
+            url = url.replace(str(datetime.now().year), "[year]")
         line = unquote("{:50} {:20} {}".format(rule.endpoint, methods, url))
 
         output.append(line)
@@ -443,43 +270,356 @@ def routes():
 
 
 @manager.command
-def update_new_value_to_boolean():
+def create_missing_request_status_changed_events():
     """
-    This manager command will query the Events table and convert all values in the new_value column to be boolean
-    True and False values instead of the strings 'true' and 'false'
+    http://nycrecords.atlassian.net/browse/OP-1532
     """
-    from sqlalchemy import or_
-    from sqlalchemy.orm.attributes import flag_modified
+    from app.constants import request_status
+    from datetime import datetime
 
-    for event in Events.query.filter(or_(Events.type == 'request_agency_description_privacy_edited',
-                                         Events.type == 'request_title_privacy_edited',
-                                         Events.type == 'note_edited',
-                                         Events.type == 'file_edited')).all():
-        new_value = event.new_value
-        if new_value:
-            for key in new_value.keys():
-                if key == 'privacy' and new_value[key] == 'true':
-                    new_value['privacy'] = True
-                if key == 'privacy' and new_value[key] == 'false':
-                    new_value['privacy'] = False
-                if key == 'deleted' and new_value[key] == 'true':
-                    new_value['deleted'] = True
-                if key == 'deleted' and new_value[key] == 'false':
-                    new_value['deleted'] = False
-        db.session.add(event)
-        flag_modified(event, 'new_value')  # needed when updating JSON columns
+    release_date = datetime(2018, 8, 30, 17, 00)
+    events = Events.query.filter(
+        Events.type.in_([event_type.REQ_CLOSED]), Events.timestamp >= release_date
+    ).all()
+
+    requests = [Requests.query.filter_by(id=e.request_id).one() for e in events]
+
+    for request in requests:
+        # Get the time for the "request_closed" event
+        request_closed_date = Events.query.filter_by(
+            request_id=request.id, type=event_type.REQ_CLOSED
+        ).all()
+        if len(request_closed_date) == 1:
+            request_closed_event = request_closed_date[0]
+
+            # Determine if the request was "Due Soon" or "Overdue" at some point
+            has_request_status_changed = Events.query.filter(
+                Events.type == event_type.REQ_STATUS_CHANGED,
+                Events.request_id == request.id,
+            ).all()
+            if has_request_status_changed:
+                # Get the last request_status_changed event from the database
+                has_request_status_changed.sort(key=lambda x: x.timestamp, reverse=True)
+                last_status = has_request_status_changed[0]
+            else:
+                last_status = []
+
+            if last_status:
+                # This request was "Due Soon" or "Overdue"; We'll use the last status (from the request_status_changed
+                # new_value) to insert the request_status_changed event for this into the DB
+                event = Events(
+                    request_id=request.id,
+                    user_guid=request_closed_event.user_guid,
+                    auth_user_type=request_closed_event.auth_user_type,
+                    type_=event_type.REQ_STATUS_CHANGED,
+                    previous_value={
+                        "status": last_status.new_value["status"],
+                        "date_closed": None,
+                    },
+                    new_value={
+                        "status": request_status.CLOSED,
+                        "date_closed": request_closed_event.timestamp.isoformat(),
+                    },
+                    timestamp=request_closed_event.timestamp
+                    - timedelta(microseconds=30),
+                )
+                print(
+                    request.id,
+                    request.date_closed,
+                    event.timestamp,
+                    event.previous_value,
+                    event.new_value,
+                )
+
+                db.session.add(event)
+            else:
+                # Determine if the previous status was "In Progress" (the request was previously acknowledged, or
+                # "Open" (the request was denied outright)
+                was_acknowledged = (
+                    request.responses.join(Determinations)
+                    .filter(Determinations.dtype == determination_type.ACKNOWLEDGMENT)
+                    .one_or_none()
+                )
+                if was_acknowledged:
+                    # The request was acknowledged, so the previous status has to be "In Progress"
+                    event = Events(
+                        request_id=request.id,
+                        user_guid=request_closed_event.user_guid,
+                        auth_user_type=request_closed_event.auth_user_type,
+                        type_=event_type.REQ_STATUS_CHANGED,
+                        previous_value={
+                            "status": request_status.IN_PROGRESS,
+                            "date_closed": None,
+                        },
+                        new_value={
+                            "status": request_status.CLOSED,
+                            "date_closed": request_closed_event.timestamp.isoformat(),
+                        },
+                        timestamp=request_closed_event.timestamp
+                        - timedelta(microseconds=30),
+                    )
+                    print(
+                        request.id,
+                        request.date_closed,
+                        event.timestamp,
+                        event.previous_value,
+                        event.new_value,
+                    )
+
+                    db.session.add(event)
+                else:
+                    # The request was not acnkowledged, so the previous status has to be "Open"
+                    event = Events(
+                        request_id=request.id,
+                        user_guid=request_closed_event.user_guid,
+                        auth_user_type=request_closed_event.auth_user_type,
+                        type_=event_type.REQ_STATUS_CHANGED,
+                        previous_value={
+                            "status": request_status.OPEN,
+                            "date_closed": None,
+                        },
+                        new_value={
+                            "status": request_status.CLOSED,
+                            "date_closed": request_closed_event.timestamp.isoformat(),
+                        },
+                        timestamp=request_closed_event.timestamp
+                        - timedelta(microseconds=30),
+                    )
+                    print(
+                        request.id,
+                        request.date_closed,
+                        event.timestamp,
+                        event.previous_value,
+                        event.new_value,
+                    )
+
+                    db.session.add(event)
+        else:
+            # Handle requests that were closed multiple times
+            request_closed_date.sort(key=lambda x: x.timestamp, reverse=True)
+            for closing in request_closed_date[:-1]:
+                # The last request has to be handled differently.
+                next_closing = request_closed_date.index(closing) + 1
+                # Find all request status changes that happened in between the current closing and the previous closing.
+                has_request_status_changed = Events.query.filter(
+                    Events.type == event_type.REQ_STATUS_CHANGED,
+                    Events.request_id == request.id,
+                    Events.timestamp < closing.timestamp,
+                    Events.timestamp >= request_closed_date[next_closing].timestamp,
+                ).all()
+
+                if has_request_status_changed:
+                    # Get the last request_status_changed event from the database
+                    has_request_status_changed.sort(
+                        key=lambda x: x.timestamp, reverse=True
+                    )
+                    last_status = has_request_status_changed[0]
+                else:
+                    last_status = []
+
+                if last_status:
+                    # This request was "Due Soon" or "Overdue"; We'll use the last status (from the request_status
+                    # _changed new_value) to insert the request_status_changed event for this into the DB
+                    event = Events(
+                        request_id=request.id,
+                        user_guid=closing.user_guid,
+                        auth_user_type=closing.auth_user_type,
+                        type_=event_type.REQ_STATUS_CHANGED,
+                        previous_value={
+                            "status": last_status.new_value["status"],
+                            "date_closed": None,
+                        },
+                        new_value={
+                            "status": request_status.CLOSED,
+                            "date_closed": closing.timestamp.isoformat(),
+                        },
+                        timestamp=closing.timestamp - timedelta(microseconds=30),
+                    )
+                    print(
+                        request.id,
+                        closing.timestamp,
+                        event.timestamp,
+                        event.previous_value,
+                        event.new_value,
+                    )
+                    db.session.add(event)
+                else:
+                    # Determine if the previous status was "In Progress" (the request was previously acknowledged, or
+                    # "Open" (the request was denied outright)
+                    was_acknowledged = (
+                        request.responses.join(Determinations)
+                        .filter(
+                            Determinations.dtype == determination_type.ACKNOWLEDGMENT
+                        )
+                        .one_or_none()
+                    )
+                    if was_acknowledged:
+                        # The request was acknowledged, so the previous status has to be "In Progress"
+                        event = Events(
+                            request_id=request.id,
+                            user_guid=closing.user_guid,
+                            auth_user_type=closing.auth_user_type,
+                            type_=event_type.REQ_STATUS_CHANGED,
+                            previous_value={
+                                "status": request_status.IN_PROGRESS,
+                                "date_closed": None,
+                            },
+                            new_value={
+                                "status": request_status.CLOSED,
+                                "date_closed": closing.timestamp.isoformat(),
+                            },
+                            timestamp=closing.timestamp - timedelta(microseconds=30),
+                        )
+                        print(
+                            request.id,
+                            closing.timestamp,
+                            event.timestamp,
+                            event.previous_value,
+                            event.new_value,
+                        )
+
+                        db.session.add(event)
+                    else:
+                        # The request was not acnkowledged, so the previous status has to be "Open"
+                        event = Events(
+                            request_id=request.id,
+                            user_guid=closing.user_guid,
+                            auth_user_type=closing.auth_user_type,
+                            type_=event_type.REQ_STATUS_CHANGED,
+                            previous_value={
+                                "status": request_status.OPEN,
+                                "date_closed": None,
+                            },
+                            new_value={
+                                "status": request_status.CLOSED,
+                                "date_closed": closing.timestamp.isoformat(),
+                            },
+                            timestamp=closing.timestamp - timedelta(microseconds=30),
+                        )
+                        print(
+                            request.id,
+                            closing.timestamp,
+                            event.timestamp,
+                            event.previous_value,
+                            event.new_value,
+                        )
+
+                        db.session.add(event)
+            closing = request_closed_date[-1]
+            has_request_status_changed = Events.query.filter(
+                Events.type == event_type.REQ_STATUS_CHANGED,
+                Events.request_id == request.id,
+                Events.timestamp < closing.timestamp,
+            ).all()
+
+            if has_request_status_changed:
+                # Get the last request_status_changed event from the database
+                has_request_status_changed.sort(key=lambda x: x.timestamp, reverse=True)
+                last_status = has_request_status_changed[0]
+            else:
+                last_status = []
+
+            if last_status:
+                # This request was "Due Soon" or "Overdue"; We'll use the last status (from the request_status
+                # _changed new_value) to insert the request_status_changed event for this into the DB
+                event = Events(
+                    request_id=request.id,
+                    user_guid=closing.user_guid,
+                    auth_user_type=closing.auth_user_type,
+                    type_=event_type.REQ_STATUS_CHANGED,
+                    previous_value={
+                        "status": last_status.new_value["status"],
+                        "date_closed": None,
+                    },
+                    new_value={
+                        "status": request_status.CLOSED,
+                        "date_closed": closing.timestamp.isoformat(),
+                    },
+                    timestamp=closing.timestamp - timedelta(microseconds=30),
+                )
+                print(
+                    request.id,
+                    closing.timestamp,
+                    event.timestamp,
+                    event.previous_value,
+                    event.new_value,
+                )
+                db.session.add(event)
+            else:
+                # Determine if the previous status was "In Progress" (the request was previously acknowledged, or
+                # "Open" (the request was denied outright)
+                was_acknowledged = (
+                    request.responses.join(Determinations)
+                    .filter(Determinations.dtype == determination_type.ACKNOWLEDGMENT)
+                    .one_or_none()
+                )
+                if was_acknowledged:
+                    # The request was acknowledged, so the previous status has to be "In Progress"
+                    event = Events(
+                        request_id=request.id,
+                        user_guid=closing.user_guid,
+                        auth_user_type=closing.auth_user_type,
+                        type_=event_type.REQ_STATUS_CHANGED,
+                        previous_value={
+                            "status": request_status.IN_PROGRESS,
+                            "date_closed": None,
+                        },
+                        new_value={
+                            "status": request_status.CLOSED,
+                            "date_closed": closing.timestamp.isoformat(),
+                        },
+                        timestamp=closing.timestamp - timedelta(microseconds=30),
+                    )
+                    print(
+                        request.id,
+                        closing.timestamp,
+                        event.timestamp,
+                        event.previous_value,
+                        event.new_value,
+                    )
+                    db.session.add(event)
+                else:
+                    # The request was not acnkowledged, so the previous status has to be "Open"
+                    event = Events(
+                        request_id=request.id,
+                        user_guid=closing.user_guid,
+                        auth_user_type=closing.auth_user_type,
+                        type_=event_type.REQ_STATUS_CHANGED,
+                        previous_value={
+                            "status": request_status.OPEN,
+                            "date_closed": None,
+                        },
+                        new_value={
+                            "status": request_status.CLOSED,
+                            "date_closed": closing.timestamp.isoformat(),
+                        },
+                        timestamp=closing.timestamp - timedelta(microseconds=30),
+                    )
+                    print(
+                        request.id,
+                        closing.timestamp,
+                        event.timestamp,
+                        event.previous_value,
+                        event.new_value,
+                    )
+                    db.session.add(event)
     db.session.commit()
 
+@manager.command
+def fix_incorrect_key_events():
+    from sqlalchemy.orm.attributes import flag_modified
 
-# @manager.option('-t', '--testing', help='Full path to output csv. File will be overwritten.', default=False)
-# def celery(testing):
-#
-#     celery_command = ['celery', 'worker', '-A', 'celery_worker.celery', '--loglevel=info']
-#
-#     if testing:
-#         os.environ['FLASK_CONFIG'] = 'testing'
-#
-#     subprocess.Popen(celery_command)
+    events = Events.query.filter(Events.type == "request_status_changed").all()
+
+    for event in events:
+        if "request" in event.previous_value:
+            print(event.request_id)
+            event.previous_value["status"] = event.previous_value["request"]
+            event.previous_value.pop("request", None)
+            db.session.add(event)
+            flag_modified(event, "previous_value")
+
+    db.session.commit()
 
 
 if __name__ == "__main__":

--- a/manage.py
+++ b/manage.py
@@ -27,7 +27,7 @@ from app.models import (
     Determinations,
 )
 from app.request.utils import generate_guid
-from app.constants import user_type_auth, event_type, request_status, determination_type
+from app.constants import user_type_auth, event_type, determination_type
 from app.lib.user_information import create_mailing_address
 
 COV = None
@@ -579,7 +579,7 @@ def create_missing_request_status_changed_events():
                     )
                     db.session.add(event)
                 else:
-                    # The request was not acnkowledged, so the previous status has to be "Open"
+                    # The request was not acknowledge, so the previous status has to be "Open"
                     event = Events(
                         request_id=request.id,
                         user_guid=closing.user_guid,
@@ -607,6 +607,9 @@ def create_missing_request_status_changed_events():
 
 @manager.command
 def fix_incorrect_key_events():
+    """
+    Fixes Events table for request_status_changed events with a key of 'request' instead of 'status'
+    """
     from sqlalchemy.orm.attributes import flag_modified
 
     events = Events.query.filter(Events.type == "request_status_changed").all()


### PR DESCRIPTION
To test this functionality:
1) Import the latest Production DB backup into your local environment
2) Run `python manage.py fix_incorrect_key_events`
`# Fixes request_status_changed with key of 'request' instead of 'status'`
3) Run `python manage.py create_missing_request_status_changed_events` 
`# Inserts missing request_status_changed events`

Adds a CLI flag for updating the events table to include
request_status_changed events for requests closed between the current
date and the release of v2.3.

Additionally update the Events table to resolve an incorrect key for
request status changes (jobs.py) and use the REQ_DENIED event
instead of REQ_CLOSED for denials

Finally, adds a request_status_changed event for acknowledging a
request.

