### PR TITLE
bugfix/OP-1538: Remove pycrypto from requirements.txt

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -52,7 +52,6 @@ Pillow==5.0.0
 psycopg2>2.7
 pyasn1==0.2.2
 pycparser==2.17
-pycrypto==2.6.1
 pyOpenSSL==16.2.0
 pyparsing==2.1.10
 Pyphen==0.9.4


### PR DESCRIPTION
To resolve issue with PyCrypto.

As far as I can tell, we just need to run `pip uninstall -y pycrpto`.

We are not explicitly using it in our code and the dependency graph does not show any dependencies that rely on it. 

See:
- [pycrypto#253](https://github.com/dlitz/pycrypto/issues/253)
- [TElgamal/attack-on-pycrypto-elgamal](https://github.com/TElgamal/attack-on-pycrypto-elgamal)
- [pycrypto#275](https://github.com/dlitz/pycrypto/issues/275)
- [pycrypto#158](https://github.com/dlitz/pycrypto/issues/158)