### PR TITLE
Bugfix/OP-1546: Resolve Missing `timestamp` issue

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1250,7 +1250,9 @@ class Responses(db.Model):
         :return: timestamp of the newest event row associated with a response
         """
         timestamps = Events.query.filter_by(response_id=self.id).order_by(desc(Events.timestamp)).all()
-        return timestamps[0].timestamp
+        if timestamps:
+            return timestamps[0].timestamp
+        return self.date_modified
 
     def make_public(self):
         self.privacy = response_privacy.RELEASE_AND_PUBLIC


### PR DESCRIPTION
Responses created prior to the launch of OpenRecords v2.0 do not have entries in the events table. When filling in the responses section, we pull the timestamp for the event associated with a response. This obviously fails if the response has no associated event.

To resolve this issue, a check has been put in place to see if the event exists (the query returns a value instead of `None`). If the query returns `None` (actually an empty list), then we default to using the response date_modified, which is a close analogy to the event timestamp.