### PR TITLE
Bugfix/OP-1558: Not Able to Edit Anonymous Requester Mailing Address

### DIFF
--- a/app/user/views.py
+++ b/app/user/views.py
@@ -238,9 +238,9 @@ def patch(user_id):
             new['auth_user_type'] = user_.auth_user_type
 
             if new_address:
-                new['mailing_address'] = new_address
+                new['_mailing_address'] = new_address
             if old_address:
-                old['mailing_address'] = old_address
+                old['_mailing_address'] = old_address
 
             if ('is_agency_admin' in new) or ('is_agency_active' in new):
                 new['agency_ein'] = agency_ein


### PR DESCRIPTION
Caused by https://github.com//cityofnewyork/nycopenrecords/commit/739cc7c86f4a96bd40a86e434d970c0433276363

Users unable to modify mailing address because database attribute name is now _mailing_address.

DB_Utils must map the database attribute name when doing and update, not the name in the Python code.

