### PR TITLE
Bugfix/OP-1562: Elasticsearch Reindex Fails for Agency Request Summary Release Date

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -894,7 +894,8 @@ class Requests(db.Model):
     @property
     def agency_request_summary_released(self):
         return self.status == request_status.CLOSED and not self.privacy['agency_request_summary'] and \
-               self.agency_request_summary and self.agency_request_summary_release_date < datetime.utcnow()
+               self.agency_request_summary and self.agency_request_summary_release_date is not None and \
+               self.agency_request_summary_release_date < datetime.utcnow()
 
     def es_update(self):
         if self.agency.is_active:

--- a/app/models.py
+++ b/app/models.py
@@ -893,6 +893,9 @@ class Requests(db.Model):
 
     @property
     def agency_request_summary_released(self):
+        '''
+        Determine whether the agency_request_summary has been made public and has passed its release date
+        '''
         return self.status == request_status.CLOSED and not self.privacy['agency_request_summary'] and \
                self.agency_request_summary and self.agency_request_summary_release_date is not None and \
                self.agency_request_summary_release_date < datetime.utcnow()


### PR DESCRIPTION
Add a check to make sure agency_request_summary_release_date exists before compare it to current date.