### PR TITLE
Feature/OP-1178: Request Page Accessibility - Heading Structure

### DIFF
--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -215,3 +215,11 @@ input[type="radio"], input[type="checkbox"] {
     background-color: green;
     border-color: green;
 }
+
+.character-counter {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.1;
+    margin-top: 10px;
+    margin-bottom: 10px;
+}

--- a/app/templates/auth/manage_account.html
+++ b/app/templates/auth/manage_account.html
@@ -39,7 +39,7 @@
                 class='input-block-level',
                 placeholder='Your role in your organization (if applicable)',
                 maxlength="64") }}
-            <h5 id="title-character-count">64 characters remaining</h5>
+            <p id="title-character-count" class="character-counter">64 characters remaining</p>
             <br>
             {{ form.organization.label(class='request-heading') }}
             {{ form.organization(
@@ -47,7 +47,7 @@
                 class='input-block-level',
                 placeholder='Your organization (if applicable)',
                 maxlength="128") }}
-            <h5 id="organization-character-count">128 characters remaining</h5>
+            <p id="organization-character-count" class="character-counter">128 characters remaining</p>
             <br>
             <div class="contact-form-error-message"></div>
 

--- a/app/templates/custom_request_form_templates/input_template.html
+++ b/app/templates/custom_request_form_templates/input_template.html
@@ -12,7 +12,7 @@
            {% endif %}
            {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}>
     {% if max_length and character_counter %}
-        <h5 id="{{ field_name }}-{{ instance_id }}-character-count">{{ max_length }} characters remaining</h5>
+        <p id="{{ field_name }}-{{ instance_id }}-character-count" class="character-counter">{{ max_length }} characters remaining</p>
     {% endif %}
     <br>
 </div>

--- a/app/templates/custom_request_form_templates/textarea_template.html
+++ b/app/templates/custom_request_form_templates/textarea_template.html
@@ -12,7 +12,7 @@
               {% endif %}
               {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}></textarea>
     {% if max_length and character_counter %}
-        <h5 id="{{ field_name }}-{{ instance_id }}-character-count">{{ max_length }} characters remaining</h5>
+        <p id="{{ field_name }}-{{ instance_id }}-character-count" class="character-counter">{{ max_length }} characters remaining</p>
     {% endif %}
     <br>
 </div>

--- a/app/templates/main/contact.html
+++ b/app/templates/main/contact.html
@@ -18,18 +18,18 @@
 
             <label for="name">Name</label>
             <input id="name" class="form-control" name="name" maxlength="32" type="text">
-            <h5 id="name-character-count">32 characters remaining</h5>
+            <p id="name-character-count" class="character-counter">32 characters remaining</p>
             <br>
             <label for="email">Email</label>
             <input id="email" class="form-control" name="email" maxlength="254" type="email">
             <br>
             <label for="subject">Subject</label>
             <input id="subject" class="form-control" name="subject" maxlength="90" type="text" value="{{ error_id }}">
-            <h5 id="subject-character-count">90 characters remaining</h5>
+            <p id="subject-character-count" class="character-counter">90 characters remaining</p>
             <br>
             <label for="message">Message</label>
             <textarea id="message" name="message" rows="10" maxlength="5000"></textarea>
-            <h5 id="message-character-count">5000 characters remaining</h5>
+            <p id="message-character-count" class="character-counter">5000 characters remaining</p>
 
             <br>
             <input id="submit" name="submit" type="submit" value="Send">

--- a/app/templates/request/_edit_requester_info.html
+++ b/app/templates/request/_edit_requester_info.html
@@ -31,12 +31,12 @@
                     {{ edit_requester_form.title.label }}
                     {{ edit_requester_form.title(id='inputTitle', class='form-control', maxlength="64",
                         readonly=is_public_requester) }}
-                    <h5 id="user-title-character-count">64 characters remaining</h5>
+                    <p id="user-title-character-count" class="character-counter">64 characters remaining</p>
 
                     {{ edit_requester_form.organization.label }}
                     {{ edit_requester_form.organization(id='inputOrganization', class='form-control', maxlength="128",
                         readonly=is_public_requester) }}
-                    <h5 id="organization-character-count">128 characters remaining</h5>
+                    <p id="organization-character-count" class="character-counter">128 characters remaining</p>
 
                     {{ edit_requester_form.phone.label }}
                     {{ edit_requester_form.phone(id='inputTelephone', class='form-control',

--- a/app/templates/request/_view_request_contact_modal.html
+++ b/app/templates/request/_view_request_contact_modal.html
@@ -12,12 +12,12 @@
 
                     {{ contact_agency_form.first_name.label }}
                     {{ contact_agency_form.first_name(id="first-name", class="form-control", maxlength="32") }}
-                    <h5 id="first-name-character-count">32 characters remaining</h5>
+                    <p id="first-name-character-count" class="character-counter">32 characters remaining</p>
                     <br/>
 
                     {{ contact_agency_form.last_name.label }}
                     {{ contact_agency_form.last_name(id="last-name", class="form-control", maxlength="64") }}
-                    <h5 id="last-name-character-count">64 characters remaining</h5>
+                    <p id="last-name-character-count" class="character-counter">64 characters remaining</p>
                     <br/>
 
                     {{ contact_agency_form.email.label }}
@@ -30,7 +30,7 @@
 
                     {{ contact_agency_form.message.label }}
                     {{ contact_agency_form.message(id="message", class="form-control", rows="10", maxlength="5000") }}
-                    <h5 id="message-character-count">5000 characters remaining</h5>
+                    <p id="message-character-count" class="character-counter">5000 characters remaining</p>
 
                     <br/>
                     {{ contact_agency_form.submit(id="submit") }}

--- a/app/templates/request/new_request_agency.html
+++ b/app/templates/request/new_request_agency.html
@@ -39,12 +39,12 @@
                 {% endif %}
                 <div class="panel panel-info agency-instructions-panel" id="request-agency-instructions" hidden>
                     <div class="panel-heading">
-                        <h4 class="panel-title agency-instructions-title">
+                        <p class="panel-title agency-instructions-title">
                             <a id="agency-instructions-title-text" data-toggle="collapse"
                                href="#collapse-agency-instructions"><span
                                     class="glyphicon glyphicon-chevron-down"></span>&nbsp;&nbsp;Show Agency Instructions&nbsp;&nbsp;<span
                                     class="glyphicon glyphicon-chevron-down"></span></a>
-                        </h4>
+                        </p>
                     </div>
                     <div id="collapse-agency-instructions" class="panel-collapse collapse">
                         <div class="panel-body" id="request-agency-instructions-content"></div>
@@ -59,7 +59,7 @@
                 </span>
                 {{ form.request_title(id="request-title", class="input-block-level",
                         placeholder="Please provide a short summary of your request.", maxlength="90") }}
-                <h5 id="title-character-count">90 characters remaining</h5>
+                <p id="title-character-count" class="character-counter">90 characters remaining</p>
                 <div class="alert alert-info">
                     <p><strong>
                         Note: The title of this request will be visible to the public.
@@ -76,7 +76,7 @@
                     {{ form.request_description(id="request-description", class="input-block-level",
                     placeholder="Provide more information about your request to help the City locate the record. If you don't know the record name, describe the type of information you think it would contain and the approximate date range. Do not include private information such as a social security # or credit card.",
                         maxlength="5000") }}
-                    <h5 id="description-character-count">5000 characters remaining</h5>
+                    <p id="description-character-count" class="character-counter">5000 characters remaining</>
                     <div class="alert alert-info">
                         <p><b>Note: The request details written here will not be visible to the public.
                             However, your agency may post a description of the records provided.</b></p>
@@ -111,7 +111,7 @@
                         <div class="modal-dialog vertical-align-center">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Confirm Delete</h4>
+                                    <strong class="modal-title">Confirm Delete</strong>
                                 </div>
                                 <div class="modal-body">
                                 </div>
@@ -130,7 +130,7 @@
                         <div class="modal-dialog vertical-align-center">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Warning</h4>
+                                    <strong class="modal-title">Warning</strong>
                                 </div>
                                 <div id="category-warning-text" class="modal-body">Selecting this option will remove any
                                     existing information for other request types. Are you sure you want to change
@@ -166,7 +166,7 @@
                     {% endif %}
                 </div>
 
-                <h1>Private Information</h1>
+                <h2>Private Information</h2>
                 <div class="request-heading">
                     Receipt Information
                 </div>
@@ -179,37 +179,37 @@
                 Request Date (required)
                 {{ form.request_date(id="request-date", class="input-block-level dtpick") }}
 
-                <h1>Personal Information
+                <h2>Personal Information
                     <small data-toggle="popover" data-placement="right" data-trigger="hover"
                            title="Personal Information"
                            data-content="First and last name fields are required. The Email field is optional but recommended.">
                         <span class="glyphicon glyphicon-question-sign"></span>
                     </small>
-                </h1>
+                </h2>
 
                 <p>This information will not be publicly viewable on this site. You must provide contact
                     information so that the agency can respond to your request for records.</p>
                 {# First name of user #}
                 {{ form.first_name.label(class="request-heading first-name-label") }}
                 {{ form.first_name(id="first-name", class="input-block-level", placeholder="John", maxlength="32") }}
-                <h5 id="first-name-character-count">32 characters remaining</h5><br>
+                <p id="first-name-character-count" class="character-counter">32 characters remaining</p><br>
                 {# Last name of user #}
                 {{ form.last_name.label(class="request-heading last-name-label") }}
                 {{ form.last_name(id="last-name", class="input-block-level", placeholder="Doe", maxlength="64") }}
-                <h5 id="last-name-character-count">64 characters remaining</h5><br>
+                <p id="last-name-character-count" class="character-counter">64 characters remaining</p><br>
                 {# Email of user #}
                 {{ form.email.label(class="request-heading email-label") }}
                 {{ form.email(id="email", class="input-block-level",
                 placeholder="requester@email.com", maxlength="254") }}<br>
 
                 <div class="contact-form-error-message"></div>
-                <h1>Alternate Contact Information
+                <h2>Alternate Contact Information
                     <small data-toggle="popover" data-placement="right" data-trigger="hover"
                            title="Alternate Contact Information"
                            data-content="Fields are included in case alternate contact method is needed.">
                         <span class="glyphicon glyphicon-question-sign"></span>
                     </small>
-                </h1>
+                </h2>
 
                 <p>No information entered in this section will be visible to the public.</p>
                 <p>Note: You must provide at least one type of contact information (phone number, fax number, or
@@ -218,12 +218,12 @@
                 {{ form.user_title.label(class="request-heading") }}
                 {{ form.user_title(id="user-title", class="input-block-level",
                 placeholder="Your role in your organization (if applicable)", maxlength="64") }}
-                <h5 id="user-title-character-count">64 characters remaining</h5><br>
+                <p id="user-title-character-count" class="character-counter">64 characters remaining</p><br>
                 {# Organization/Agency user belongs to #}
                 {{ form.user_organization.label(class="request-heading") }}
                 {{ form.user_organization(id="user-organization", class="input-block-level",
                 placeholder="Your organization (if applicable)", maxlength="128") }}
-                <h5 id="organization-character-count">128 characters remaining</h5><br>
+                <p id="organization-character-count" class="character-counter">128 characters remaining</p><br>
                 {# Phone number of user #}
                 {{ form.phone.label(class="request-heading") }}
                 {{ form.phone(id="phone", class="input-block-level",

--- a/app/templates/request/new_request_anon.html
+++ b/app/templates/request/new_request_anon.html
@@ -42,12 +42,12 @@
                 {{ form.request_agency(id="request-agency", class="input-block-level") }}<br>
                 <div class="panel panel-info agency-instructions-panel" id="request-agency-instructions" hidden>
                     <div class="panel-heading">
-                        <h4 class="panel-title agency-instructions-title">
+                        <p class="panel-title agency-instructions-title">
                             <a id="agency-instructions-title-text" data-toggle="collapse"
                                href="#collapse-agency-instructions"><span
                                     class="glyphicon glyphicon-chevron-down"></span>&nbsp;&nbsp;Hide Agency Instructions&nbsp;&nbsp;<span
                                     class="glyphicon glyphicon-chevron-down"></span></a>
-                        </h4>
+                        </p>
                     </div>
                     <div id="collapse-agency-instructions" class="panel-collapse collapse in">
                         <div class="panel-body" id="request-agency-instructions-content"></div>
@@ -66,7 +66,7 @@
                 </div>
                 {{ form.request_title(id="request-title", class="input-block-level",
                         placeholder="Please provide a short summary of your request.", maxlength="90") }}
-                <h5 id="title-character-count">90 characters remaining</h5>
+                <p id="title-character-count" class="character-counter">90 characters remaining</p>
 
                 {# Description of Request #}
                 <div id="request-description-section">
@@ -82,7 +82,7 @@
                     {{ form.request_description(id="request-description", class="input-block-level",
                     placeholder="Provide more information about your request to help the City locate the record. If you don't know the record name, describe the type of information you think it would contain and the approximate date range. Do not include private information such as a social security # or credit card.",
                         maxlength="5000") }}
-                    <h5 id="description-character-count">5000 characters remaining</h5>
+                    <p id="description-character-count" class="character-counter">5000 characters remaining</p>
                 </div>
 
                 {# Dropdown for request type based on custom request forms #}
@@ -113,7 +113,7 @@
                         <div class="modal-dialog vertical-align-center">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Confirm Delete</h4>
+                                    <strong class="modal-title">Confirm Delete</strong>
                                 </div>
                                 <div class="modal-body">
                                 </div>
@@ -132,7 +132,7 @@
                         <div class="modal-dialog vertical-align-center">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Warning</h4>
+                                    <strong class="modal-title">Warning</strong>
                                 </div>
                                 <div id="category-warning-text" class="modal-body">Selecting this option will remove any
                                     existing information for other request types. Are you sure you want to change
@@ -168,48 +168,48 @@
                     {% endif %}
                 </div>
 
-                <h1>Personal Information
+                <h2>Personal Information
                     <small data-toggle="popover" data-placement="right" data-trigger="hover"
                            title="Personal Information"
                            data-content="First and last name fields are required. The Email field is optional but recommended.">
                         <span class="glyphicon glyphicon-question-sign"></span>
                     </small>
-                </h1>
+                </h2>
 
                 <p>This information will not be publicly viewable on this site. You must provide contact
                     information so that the agency can respond to your request for records.</p>
                 {# First name field #}
                 {{ form.first_name.label(class="request-heading first-name-label") }}
                 {{ form.first_name(id="first-name", class="input-block-level", placeholder="John", maxlength="32") }}
-                <h5 id="first-name-character-count">32 characters remaining</h5><br>
+                <p id="first-name-character-count" class="character-counter">32 characters remaining</p><br>
                 {# Last name field #}
                 {{ form.last_name.label(class="request-heading last-name-label") }}
                 {{ form.last_name(id="last-name", class="input-block-level", placeholder="Doe", maxlength="64") }}
-                <h5 id="last-name-character-count">64 characters remaining</h5><br>
+                <p id="last-name-character-count" class="character-counter">64 characters remaining</p><br>
                 {# Email field #}
                 {{ form.email.label(class="request-heading email-label") }}
                 {{ form.email(id="email", class="input-block-level",
                 placeholder="requester@email.com", maxlength="254") }}<br>
 
                 <div class="contact-form-error-message"></div>
-                <h1>Alternate Contact Information
+                <h2>Alternate Contact Information
                     <small data-toggle="popover" data-placement="right" data-trigger="hover"
                            title="Alternate Contact Information"
                            data-content="Fields are included in case alternate contact method is needed.">
                         <span class="glyphicon glyphicon-question-sign"></span>
                     </small>
-                </h1>
+                </h2>
                 <p>No information entered in this section will be visible to the public.</p>
                 {# Title of user #}
                 {{ form.user_title.label(class="request-heading") }}
                 {{ form.user_title(id="user-title", class="input-block-level",
                 placeholder="Your role in your organization (if applicable)", maxlength="64") }}
-                <h5 id="user-title-character-count">64 characters remaining</h5><br>
+                <p id="user-title-character-count" class="character-counter">64 characters remaining</p><br>
                 {# Organization user belongs to #}
                 {{ form.user_organization.label(class="request-heading") }}
                 {{ form.user_organization(id="user-organization", class="input-block-level",
                 placeholder="Your organization (if applicable)", maxlength="128") }}
-                <h5 id="organization-character-count">128 characters remaining</h5><br>
+                <p id="organization-character-count" class="character-counter">128 characters remaining</p><br>
                 {# User's phone number #}
                 {{ form.phone.label(class="request-heading") }}
                 {{ form.phone(id="phone", class="input-block-level",

--- a/app/templates/request/new_request_user.html
+++ b/app/templates/request/new_request_user.html
@@ -41,12 +41,12 @@
                 {{ form.request_agency(id="request-agency", class="input-block-level") }}<br>
                 <div class="panel panel-info agency-instructions-panel" id="request-agency-instructions" hidden>
                     <div class="panel-heading">
-                        <h4 class="panel-title agency-instructions-title">
+                        <p class="panel-title agency-instructions-title">
                             <a id="agency-instructions-title-text" data-toggle="collapse"
                                href="#collapse-agency-instructions"><span
                                     class="glyphicon glyphicon-chevron-down"></span>&nbsp;&nbsp;Hide Agency Instructions&nbsp;&nbsp;<span
                                     class="glyphicon glyphicon-chevron-down"></span></a>
-                        </h4>
+                        </p>
                     </div>
                     <div id="collapse-agency-instructions" class="panel-collapse collapse in">
                         <div class="panel-body" id="request-agency-instructions-content"></div>
@@ -64,7 +64,7 @@
                 </div>
                 {{ form.request_title(id="request-title", class="input-block-level",
                     placeholder="Please provide a short summary of your request.", maxlength="90") }}
-                <h5 id="title-character-count">90 characters remaining</h5>
+                <p id="title-character-count" class="character-counter">90 characters remaining</p>
                 {# Description of Request #}
                 <div id="request-description-section">
                     {{ form.request_description.label(class="request-heading description-label") }}
@@ -79,7 +79,7 @@
                     {{ form.request_description(id="request-description", class="input-block-level",
                     placeholder="Provide more information about your request to help the City locate the record. If you don't know the record name, describe the type of information you think it would contain and the approximate date range. Do not include private information such as a social security # or credit card.",
                         maxlength="5000") }}
-                    <h5 id="description-character-count">5000 characters remaining</h5>
+                    <p id="description-character-count" class="character-counter">5000 characters remaining</p>
                 </div>
 
                 {# Dropdown for request type based on custom request forms #}
@@ -110,7 +110,7 @@
                         <div class="modal-dialog vertical-align-center">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Confirm Delete</h4>
+                                    <strong class="modal-title">Confirm Delete</strong>
                                 </div>
                                 <div class="modal-body">
                                 </div>
@@ -129,7 +129,7 @@
                         <div class="modal-dialog vertical-align-center">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h4 class="modal-title">Warning</h4>
+                                    <strong class="modal-title">Warning</strong>
                                 </div>
                                 <div id="category-warning-text" class="modal-body">Selecting this option will remove any
                                     existing information for other request types. Are you sure you want to change

--- a/app/templates/request/responses/modal_body/files.html
+++ b/app/templates/request/responses/modal_body/files.html
@@ -32,7 +32,7 @@ and current_request.status != request_status.CLOSED %}
                 <input id="edit-file-title-{{ response.id }}" type="text" name="title" value="{{ response.title }}"
                        title="title" aria-describedby="title" data-parsley-maxlength="250" maxlength="250">
             </div>
-            <h5 id="edit-file-title-character-counter-{{ response.id }}">{{ 250 - response.title|length }} characters remaining</h5>
+            <p id="edit-file-title-character-counter-{{ response.id }}" class="character-counter">{{ 250 - response.title|length }} characters remaining</p>
             <div class="title-error pull-right"></div>
         {% else %}
             <div>

--- a/app/templates/request/responses/modal_body/instructions.html
+++ b/app/templates/request/responses/modal_body/instructions.html
@@ -9,9 +9,9 @@ and current_request.status != request_status.CLOSED %}
             <div class="instruction-error-messages alert alert-danger" hidden></div>
             <textarea class="input-block-level form-group instruction-content"
                       title="content" name="content" maxlength="500">{{ response.content }}</textarea>
-            <h5 class="required instruction-content-character-count">
+            <p class="required instruction-content-character-count character-counter">
                 500 characters remaining
-            </h5>
+            </p>
         {% else %}
             {{ response.content }}
         {% endif %}

--- a/app/templates/request/responses/modal_body/notes.html
+++ b/app/templates/request/responses/modal_body/notes.html
@@ -21,9 +21,9 @@ and current_request.status != request_status.CLOSED %}
         {% if edit_response_permission %}
             <textarea class="input-block-level form-group note-content"
                       title="content" name="content" maxlength="5000">{{ response.content }}</textarea>
-            <h5 class="required note-content-character-count">
+            <p class="required note-content-character-count character-counter">
                 5000 characters remaining
-            </h5>
+            </p>
         {% else %}
             {{ response.content }}
         {% endif %}

--- a/app/templates/response/add_extension.html
+++ b/app/templates/response/add_extension.html
@@ -52,7 +52,7 @@
                     <label class="extension-label">Extension Reason</label>
                     <textarea class="input-block-level form-group" id="extension-reason" name="reason"
                               maxlength="5000"></textarea>
-                    <h5 id="extension-reason-character-count">5000 characters remaining</h5>
+                    <p id="extension-reason-character-count" class="character-counter">5000 characters remaining</p>
                 </div>
                 <div id="extension-letter">
                     <label class="extension-label">Length</label>

--- a/app/templates/response/add_instruction.html
+++ b/app/templates/response/add_instruction.html
@@ -16,7 +16,7 @@
                 <label class="instruction-label">Offline Instructions</label>
                 <textarea class="input-block-level form-group" id="instruction-content" name="content"
                           minlength="20" maxlength="500"></textarea>
-                <h5 id="instruction-content-character-count">500 characters remaining</h5>
+                <p id="instruction-content-character-count" class="character-counter">500 characters remaining</p>
                 {% if permissions['edit_instructions_privacy'] %}
                     <div class="radio">
                         <label><input type="radio" class="instruction-privacy" name="privacy" value="release_public">Release

--- a/app/templates/response/add_link.html
+++ b/app/templates/response/add_link.html
@@ -16,12 +16,12 @@
                 <div class="form-group">
                     <label class="link-label">Title</label>
                     <input type="text" class="disable-enter-submit" id="link-title" name="title" maxlength="90">
-                    <h5 id="link-title-character-count">90 characters remaining</h5>
+                    <p id="link-title-character-count" class="character-counter">90 characters remaining</p>
                 </div>
                 <div class="form-group">
                     <label class="link-label">URL Link</label>
                     <input type="text" class="disable-enter-submit" id="link-url" name="url" maxlength="254">
-                    <h5 id="link-url-character-count">254 characters remaining</h5>
+                    <p id="link-url-character-count" class="character-counter">254 characters remaining</p>
                 </div>
                 {% if permissions['edit_link_privacy'] %}
                     <div class="radio">

--- a/app/templates/response/add_note.html
+++ b/app/templates/response/add_note.html
@@ -19,7 +19,7 @@
                     <label class="note-label">Note Content</label>
                     <textarea class="input-block-level form-group" id="note-content" name="content"
                               maxlength="5000"></textarea>
-                    <h5 id="note-content-character-count">5000 characters remaining</h5>
+                    <p id="note-content-character-count" class="character-counter">5000 characters remaining</p>
                     {% if current_user.is_agency %}
                         {% if permissions['edit_note_privacy'] and request.status != status.CLOSED %}
                             <div class="radio">


### PR DESCRIPTION
Updated request page to have the heading structure:
h1. Request a Record
    h2. Private Information
    h2. Personal Information
    h2. Alternate Contact Information

Changed character counters to be styled `<p>` tags that look like the previous `<h5>`