### PR TITLE
Feature/OP-1175: Updated Region Labels

### DIFF
--- a/app/templates/_nyc_gov_header.html
+++ b/app/templates/_nyc_gov_header.html
@@ -1,4 +1,4 @@
-<div class="nycidm-header" role="navigation" aria-label="Login navigation">
+<div class="nycidm-header" role="navigation" aria-label="Login">
     <div class="upper-header-black">
         <div class="container-nycidm">
             {% if not current_user.is_anonymous %}

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -1,5 +1,5 @@
 {% block navbar %}
-<nav class="navbar navbar-default" role="navigation" aria-label="Main navigation">
+<nav class="navbar navbar-default" role="navigation" aria-label="Primary">
     <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"


### PR DESCRIPTION
Updates to region labels based on Walei's comments:

The labels need edits. The label itself should not have the word navigation in it. For example, Jaws announces "Main navigation navigation region." I would also change "Main navigation" to "Primary" navigation.