### PR TITLE
Feature/OP-1472: Error Validation Accessibility

### DIFF
--- a/app/agency/api/views.py
+++ b/app/agency/api/views.py
@@ -111,6 +111,7 @@ def get_custom_request_form_fields():
     character_counters = {}
     popovers = {}
     tooltips = {}
+    error_messages = {}
     for field in custom_request_form.field_definitions:
         for key, value in field.items():
             field_text = key
@@ -125,6 +126,7 @@ def get_custom_request_form_fields():
             placeholder = value.get('placeholder', None)
             popover = value.get('popover', None)
             tooltip = value.get('tooltip', None)
+            error_message = value.get('error_message', None)
 
             if character_counter:
                 character_counter_id = field_name + "-" + str(instance_id)
@@ -139,6 +141,10 @@ def get_custom_request_form_fields():
                 tooltip_id = field_name + '-' + str(instance_id)
                 tooltips[tooltip_id] = tooltip
 
+            if error_message:
+                error_message_id = field_name + '-' + str(instance_id)
+                error_messages[error_message_id] = error_message
+
             form_template = form_template + render_template(
                 'custom_request_form_templates/{}_template.html'.format(field_type), field_text=field_text,
                 field_name=field_name, field_info=field_info, options=field_values, field_required=field_required,
@@ -148,4 +154,5 @@ def get_custom_request_form_fields():
     data['character_counters'] = character_counters
     data['popovers'] = popovers
     data['tooltips'] = tooltips
+    data['error_messages'] = error_messages
     return jsonify(data), 200

--- a/app/static/js/auth/manage-account.js
+++ b/app/static/js/auth/manage-account.js
@@ -83,11 +83,13 @@ $(document).ready(function () {
         }
         else {
             $(".contact-form-error-message").html(
+                "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
                 "At least one of the following needs to be filled: " +
                 "<strong>Notification Email</strong>, <strong>Phone</strong>, " +
                 "<strong>Fax</strong>, and/or <strong>Address</strong> " +
                 "(with <strong>City</strong>, <strong>State</strong>, and <strong>Zip code</strong>.)"
             );
+            $(".contact-form-error-message").focus();
         }
     });
 

--- a/app/static/js/request/contact.js
+++ b/app/static/js/request/contact.js
@@ -12,10 +12,12 @@ $(document).ready(function () {
     subject.attr("data-parsley-required", "");
     message.attr("data-parsley-required", "");
 
-    name.attr('data-parsley-required-message', 'This information is required.');
-    email.attr('data-parsley-required-message', 'This information is required.');
-    subject.attr('data-parsley-required-message', 'This information is required.');
-    message.attr('data-parsley-required-message', 'This information is required.');
+    // Custom validation messages
+    name.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A name is required.</strong> Please type in your name.");
+    email.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An email is required.</strong> Please type in your email.");
+    email.attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
+    subject.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A subject is required.</strong> Please type in a subject name.");
+    message.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A message is required.</strong> Please type in a message.");
 
     // Specify length requirement of certain fields
     name.attr('data-parsley-maxlength', 32);
@@ -23,7 +25,7 @@ $(document).ready(function () {
     subject.attr('data-parsley-maxlength', 90);
     message.attr('data-parsley-maxlength', 5000);
 
-    $("#contact-info").parsley().on("form:validate", function () {
+    $("#contact-info").parsley().on("form:validated", function () {
         if (name.parsley().isValid() === false) {
             $(window).scrollTop($("label[for=name]").offset().top);
         }
@@ -36,6 +38,13 @@ $(document).ready(function () {
         else {
             $(window).scrollTop($("label[for=message]").offset().top);
         }
+        // Add tab index to any error messages
+        $(".parsley-required").each(function () {
+            $(this).attr("tabindex", 0);
+        });
+        $(".parsley-type").each(function () {
+            $(this).attr("tabindex", 0);
+        });
     });
     
     // Set character counter for note content

--- a/app/static/js/request/contact.js
+++ b/app/static/js/request/contact.js
@@ -13,11 +13,21 @@ $(document).ready(function () {
     message.attr("data-parsley-required", "");
 
     // Custom validation messages
-    name.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A name is required.</strong> Please type in your name.");
-    email.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An email is required.</strong> Please type in your email.");
-    email.attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
-    subject.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A subject is required.</strong> Please type in a subject name.");
-    message.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A message is required.</strong> Please type in a message.");
+    name.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A name is required.</strong> Please type in your name.");
+    email.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>An email is required.</strong> Please type in your email.");
+    email.attr("data-parsley-type-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>This value should be an email.</strong> Please type in a valid email.");
+    subject.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A subject is required.</strong> Please type in a subject name.");
+    message.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A message is required.</strong> Please type in a message.");
 
     // Specify length requirement of certain fields
     name.attr('data-parsley-maxlength', 32);

--- a/app/static/js/request/edit_requester_info.js
+++ b/app/static/js/request/edit_requester_info.js
@@ -109,11 +109,13 @@ $(function () {
         }
         else {
             errorMessage.html(
+                "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
                 "At least one of the following needs to be filled: " +
                 "<strong>Email</strong>, <strong>Phone</strong>, <strong>Fax</strong>, " +
                 "and/or <strong>Address</strong> (with <strong>City</strong>, " +
                 "<strong>State</strong>, and <strong>Zipcode</strong>.)"
             );
+            errorMessage.focus();
         }
     });
 

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -580,6 +580,11 @@ function renderCustomRequestForm(target) {
                     return false;
                 });
 
+                // Set custom validation messages
+                for (var id in data["error_messages"]) {
+                    $("#" + id).attr("data-parsley-required-message", data["error_messages"][id]);
+                }
+
                 customRequestFormContent.show();
                 // check to show add new request information button
                 if (showMultipleRequestTypes === true) {
@@ -749,6 +754,7 @@ function processCustomRequestFormData() {
             // loop through each form field to get the value
             $("#custom-request-form-content-" + target + " > .custom-request-form-field > .custom-request-form-data").each(function () {
                 var fieldName = $("label[for='" + this.id + "']").html();
+                fieldName = fieldName.replace(" (required)", "");
                 // add leading zero to fields less than 10 so they can be properly sorted
                 if (fieldNumber < 10) {
                     fieldKey = fieldKey + "0" + fieldNumber;

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -136,9 +136,14 @@ $(document).ready(function () {
     $("#zipcode").attr("data-parsley-length", "[5,5]");
 
     // Custom Validation Messages
-    $("#fax").attr("data-parsley-length-message", "The fax number must be 10 digits.");
-    $("#phone").attr("data-parsley-length-message", "The phone number must be 10 digits.");
-    $("#zipcode").attr("data-parsley-length-message", "The Zipcode must be 5 digits.");
+    $("#request-title").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#method-received").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Format received is required.</strong> Please select a format from the drop-down menu.");
+    $("#first-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
+    $("#last-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#fax").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The fax number must be 10 digits.</strong>");
+    $("#phone").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The phone number must be 10 digits.</strong>");
+    $("#zipcode").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The zipcode must be 5 digits.</strong>");
 
     // Disable default error messages for email,phone,fax,address so custom one can be used instead.
     $("#phone").attr("data-parsley-required-message", "");
@@ -221,7 +226,7 @@ $(document).ready(function () {
         }
         else {
             // If none of the fields are valid then produce an error message and apply required fields.
-            $(".contact-form-error-message").html("*At least one of the following must be filled out: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
+            $(".contact-form-error-message").html("<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Contact information is required.</strong> Please fill out at least one of the following: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
             $("#fax").attr("data-parsley-required", "");
             $("#phone").attr("data-parsley-required", "");
             $("#address-line-1").attr("data-parsley-required", "");

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -199,7 +199,7 @@ $(document).ready(function () {
     // Contact information validation
     $("#email").attr("data-parsley-type", "email");
     // Checks that at least one form of contact was filled out in addition to the rest of the form.
-    $("#request-form").parsley().on("form:validated", function () {
+    $("#request-form").parsley().on("form:validate", function () {
         // Re-apply validators to fields in the event that they were removed from previous validation requests.
         for (var i = 0; i < requiredFields.length; i++) {
             $("#" + requiredFields[i]).attr("data-parsley-required", "");
@@ -264,10 +264,12 @@ $(document).ready(function () {
         else if ($("#email").parsley().isValid() === false) {
             $(window).scrollTop($(".email-label").offset().top);
         }
+    });
 
-        // Add tab index to any error messages
+    // Add tab index to any error messages after validation has failed
+    $("#request-form").parsley().on("form:error", function () {
         $(".parsley-required").each(function () {
-            // only add tab index to sections where error messages are currently visible
+            // Only add tab index to sections where error messages are currently visible
             if ($(this).text() !== "") {
                 $(this).attr("tabindex", 0);
             }

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -136,15 +136,33 @@ $(document).ready(function () {
     $("#zipcode").attr("data-parsley-length", "[5,5]");
 
     // Custom Validation Messages
-    $("#request-title").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
-    $("#request-description").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
-    $("#method-received").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Format received is required.</strong> Please select a format from the drop-down menu.");
-    $("#first-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
-    $("#last-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
-    $("#email").attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
-    $("#fax").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The fax number must be 10 digits.</strong>");
-    $("#phone").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The phone number must be 10 digits.</strong>");
-    $("#zipcode").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The zipcode must be 5 digits.</strong>");
+    $("#request-title").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#method-received").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>Format received is required.</strong> Please select a format from the drop-down menu.");
+    $("#first-name").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A first name is required.</strong> Please type in a your first name.");
+    $("#last-name").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#email").attr("data-parsley-type-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>This value should be an email.</strong> Please type in a valid email.");
+    $("#fax").attr("data-parsley-length-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>The fax number must be 10 digits.</strong>");
+    $("#phone").attr("data-parsley-length-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>The phone number must be 10 digits.</strong>");
+    $("#zipcode").attr("data-parsley-length-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>The zipcode must be 5 digits.</strong>");
 
     // Disable default error messages for email,phone,fax,address so custom one can be used instead.
     $("#phone").attr("data-parsley-required-message", "");
@@ -227,7 +245,9 @@ $(document).ready(function () {
         }
         else {
             // If none of the fields are valid then produce an error message and apply required fields.
-            $(".contact-form-error-message").html("<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Contact information is required.</strong> Please fill out at least one of the following: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
+            $(".contact-form-error-message").html("<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+                "<strong>Contact information is required.</strong>" +
+                " Please fill out at least one of the following: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
             $("#fax").attr("data-parsley-required", "");
             $("#phone").attr("data-parsley-required", "");
             $("#address-line-1").attr("data-parsley-required", "");

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -136,11 +136,12 @@ $(document).ready(function () {
     $("#zipcode").attr("data-parsley-length", "[5,5]");
 
     // Custom Validation Messages
-    $("#request-title").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
-    $("#request-description").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
-    $("#method-received").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Format received is required.</strong> Please select a format from the drop-down menu.");
-    $("#first-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
-    $("#last-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#request-title").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#method-received").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Format received is required.</strong> Please select a format from the drop-down menu.");
+    $("#first-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
+    $("#last-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#email").attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
     $("#fax").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The fax number must be 10 digits.</strong>");
     $("#phone").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The phone number must be 10 digits.</strong>");
     $("#zipcode").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The zipcode must be 5 digits.</strong>");
@@ -198,7 +199,7 @@ $(document).ready(function () {
     // Contact information validation
     $("#email").attr("data-parsley-type", "email");
     // Checks that at least one form of contact was filled out in addition to the rest of the form.
-    $("#request-form").parsley().on("form:validate", function () {
+    $("#request-form").parsley().on("form:validated", function () {
         // Re-apply validators to fields in the event that they were removed from previous validation requests.
         for (var i = 0; i < requiredFields.length; i++) {
             $("#" + requiredFields[i]).attr("data-parsley-required", "");
@@ -263,6 +264,19 @@ $(document).ready(function () {
         else if ($("#email").parsley().isValid() === false) {
             $(window).scrollTop($(".email-label").offset().top);
         }
+
+        // Add tab index to any error messages
+        $(".parsley-required").each(function () {
+            // only add tab index to sections where error messages are currently visible
+            if ($(this).text() !== "") {
+                $(this).attr("tabindex", 0);
+            }
+        });
+        $(".parsley-length").each(function () {
+            if ($(this).text() !== "") {
+                $(this).attr("tabindex", 0);
+            }
+        });
     });
 
     // Clear error messages for form.request_file on submit ...

--- a/app/static/js/request/new-request-anon.js
+++ b/app/static/js/request/new-request-anon.js
@@ -217,7 +217,7 @@ $(document).ready(function () {
     $("#email").attr("data-parsley-type", "email");
 
     // Checks that at least one form of contact was filled out in addition to the rest of the form.
-    $("#request-form").parsley().on("form:validated", function () {
+    $("#request-form").parsley().on("form:validate", function () {
         // Re-apply validators to fields in the event that they were removed from previous validation requests.
         for (i = 0; i < requiredFields.length; i++) {
             $("#" + requiredFields[i]).attr("data-parsley-required", "");
@@ -282,10 +282,12 @@ $(document).ready(function () {
         else if ($("#email").parsley().isValid() === false) {
             $(window).scrollTop($(".email-label").offset().top);
         }
+    });
 
+    $("#request-form").parsley().on("form:error", function () {
         // Add tab index to any error messages
         $(".parsley-required").each(function () {
-            // only add tab index to sections where error messages are currently visible
+            // Only add tab index to sections where error messages are currently visible
             if ($(this).text() !== "") {
                 $(this).attr("tabindex", 0);
             }

--- a/app/static/js/request/new-request-anon.js
+++ b/app/static/js/request/new-request-anon.js
@@ -153,9 +153,14 @@ $(document).ready(function () {
     $("#zipcode").attr("data-parsley-length", "[5,5]");
 
     // Custom Validation Messages
-    $("#fax").attr("data-parsley-length-message", "The fax number must be 10 digits.");
-    $("#phone").attr("data-parsley-length-message", "The phone number must be 10 digits.");
-    $("#zipcode").attr("data-parsley-length-message", "The Zipcode must be 5 digits.");
+    $("#request-agency").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
+    $("#request-title").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#first-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
+    $("#last-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#fax").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The fax number must be 10 digits.</strong>");
+    $("#phone").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The phone number must be 10 digits.</strong>");
+    $("#zipcode").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The zipcode must be 5 digits.</strong>");
 
     // Disable default error messages for email,phone,fax,address so custom one can be used instead.
     $("#phone").attr("data-parsley-required-message", "");
@@ -239,7 +244,7 @@ $(document).ready(function () {
         }
         else {
             // If none of the fields are valid then produce an error message and apply required fields.
-            $(".contact-form-error-message").html("*At least one of the following must be filled out: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
+            $(".contact-form-error-message").html("<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Contact information is required.</strong> Please fill out at least one of the following: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
             $("#fax").attr("data-parsley-required", "");
             $("#phone").attr("data-parsley-required", "");
             $("#address-line-1").attr("data-parsley-required", "");

--- a/app/static/js/request/new-request-anon.js
+++ b/app/static/js/request/new-request-anon.js
@@ -153,15 +153,33 @@ $(document).ready(function () {
     $("#zipcode").attr("data-parsley-length", "[5,5]");
 
     // Custom Validation Messages
-    $("#request-agency").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
-    $("#request-title").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
-    $("#request-description").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
-    $("#first-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
-    $("#last-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
-    $("#email").attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
-    $("#fax").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The fax number must be 10 digits.</strong>");
-    $("#phone").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The phone number must be 10 digits.</strong>");
-    $("#zipcode").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The zipcode must be 5 digits.</strong>");
+    $("#request-agency").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
+    $("#request-title").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#first-name").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A first name is required.</strong> Please type in a your first name.");
+    $("#last-name").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#email").attr("data-parsley-type-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>This value should be an email.</strong> Please type in a valid email.");
+    $("#fax").attr("data-parsley-length-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>The fax number must be 10 digits.</strong>");
+    $("#phone").attr("data-parsley-length-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>The phone number must be 10 digits.</strong>");
+    $("#zipcode").attr("data-parsley-length-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>The zipcode must be 5 digits.</strong>");
 
     // Disable default error messages for email,phone,fax,address so custom one can be used instead.
     $("#phone").attr("data-parsley-required-message", "");
@@ -245,7 +263,9 @@ $(document).ready(function () {
         }
         else {
             // If none of the fields are valid then produce an error message and apply required fields.
-            $(".contact-form-error-message").html("<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Contact information is required.</strong> Please fill out at least one of the following: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
+            $(".contact-form-error-message").html("<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+                "<strong>Contact information is required.</strong>" +
+                " Please fill out at least one of the following: Email, Phone, Fax, and/or Address (with City, State, and Zipcode)");
             $("#fax").attr("data-parsley-required", "");
             $("#phone").attr("data-parsley-required", "");
             $("#address-line-1").attr("data-parsley-required", "");

--- a/app/static/js/request/new-request-anon.js
+++ b/app/static/js/request/new-request-anon.js
@@ -153,11 +153,12 @@ $(document).ready(function () {
     $("#zipcode").attr("data-parsley-length", "[5,5]");
 
     // Custom Validation Messages
-    $("#request-agency").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
-    $("#request-title").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
-    $("#request-description").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
-    $("#first-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
-    $("#last-name").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#request-agency").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
+    $("#request-title").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#first-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A first name is required.</strong> Please type in a your first name.");
+    $("#last-name").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A last name is required.</strong> Please type in a your last name.");
+    $("#email").attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
     $("#fax").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The fax number must be 10 digits.</strong>");
     $("#phone").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The phone number must be 10 digits.</strong>");
     $("#zipcode").attr("data-parsley-length-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>The zipcode must be 5 digits.</strong>");
@@ -216,7 +217,7 @@ $(document).ready(function () {
     $("#email").attr("data-parsley-type", "email");
 
     // Checks that at least one form of contact was filled out in addition to the rest of the form.
-    $("#request-form").parsley().on("form:validate", function () {
+    $("#request-form").parsley().on("form:validated", function () {
         // Re-apply validators to fields in the event that they were removed from previous validation requests.
         for (i = 0; i < requiredFields.length; i++) {
             $("#" + requiredFields[i]).attr("data-parsley-required", "");
@@ -281,6 +282,19 @@ $(document).ready(function () {
         else if ($("#email").parsley().isValid() === false) {
             $(window).scrollTop($(".email-label").offset().top);
         }
+
+        // Add tab index to any error messages
+        $(".parsley-required").each(function () {
+            // only add tab index to sections where error messages are currently visible
+            if ($(this).text() !== "") {
+                $(this).attr("tabindex", 0);
+            }
+        });
+        $(".parsley-length").each(function () {
+            if ($(this).text() !== "") {
+                $(this).attr("tabindex", 0);
+            }
+        });
     });
 
     // Clear error messages for form.request_file on submit...

--- a/app/static/js/request/new-request-user.js
+++ b/app/static/js/request/new-request-user.js
@@ -161,7 +161,7 @@ $(document).ready(function () {
         }
     });
 
-    $("#request-form").parsley().on("form:validated", function () {
+    $("#request-form").parsley().on("form:validate", function () {
         // Do stuff when parsley validates
         // TODO: this or combine (see the other new-request-* js files)
         if ($("#request-file").parsley().isValid() === false) {
@@ -174,6 +174,16 @@ $(document).ready(function () {
         // Add tab index to any error messages
         $(".parsley-required").each(function () {
             // only add tab index to sections where error messages are currently visible
+            if ($(this).text() !== "") {
+                $(this).attr("tabindex", 0);
+            }
+        });
+    });
+
+    // Add tab index to any error messages after validation has failed
+    $("#request-form").parsley().on("form:error", function () {
+        $(".parsley-required").each(function () {
+            // Only add tab index to sections where error messages are currently visible
             if ($(this).text() !== "") {
                 $(this).attr("tabindex", 0);
             }

--- a/app/static/js/request/new-request-user.js
+++ b/app/static/js/request/new-request-user.js
@@ -115,9 +115,15 @@ $(document).ready(function () {
     $("#request-description").attr("data-parsley-maxlength", 5000);
 
     // Custom Validation Messages
-    $("#request-agency").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
-    $("#request-title").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
-    $("#request-description").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#request-agency").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
+    $("#request-title").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A description is required.</strong> Please type in a detailed description of your request.");
 
     // Limit the size of the file upload to 20 Mb. Second parameter is number of Mb's.
     $("#request-file").attr("data-parsley-max-file-size", "20");

--- a/app/static/js/request/new-request-user.js
+++ b/app/static/js/request/new-request-user.js
@@ -115,9 +115,9 @@ $(document).ready(function () {
     $("#request-description").attr("data-parsley-maxlength", 5000);
 
     // Custom Validation Messages
-    $("#request-agency").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
-    $("#request-title").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
-    $("#request-description").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
+    $("#request-agency").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
+    $("#request-title").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
 
     // Limit the size of the file upload to 20 Mb. Second parameter is number of Mb's.
     $("#request-file").attr("data-parsley-max-file-size", "20");
@@ -161,7 +161,7 @@ $(document).ready(function () {
         }
     });
 
-    $("#request-form").parsley().on("form:validate", function () {
+    $("#request-form").parsley().on("form:validated", function () {
         // Do stuff when parsley validates
         // TODO: this or combine (see the other new-request-* js files)
         if ($("#request-file").parsley().isValid() === false) {
@@ -170,6 +170,14 @@ $(document).ready(function () {
         else {
             $(".file-error").hide();
         }
+
+        // Add tab index to any error messages
+        $(".parsley-required").each(function () {
+            // only add tab index to sections where error messages are currently visible
+            if ($(this).text() !== "") {
+                $(this).attr("tabindex", 0);
+            }
+        });
     });
 
     // Clear error messages for form.request_file on submit .

--- a/app/static/js/request/new-request-user.js
+++ b/app/static/js/request/new-request-user.js
@@ -114,6 +114,11 @@ $(document).ready(function () {
     $("#request-description").attr("data-parsley-required", "");
     $("#request-description").attr("data-parsley-maxlength", 5000);
 
+    // Custom Validation Messages
+    $("#request-agency").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An agency is required.</strong> Please select an agency from the drop-down menu.");
+    $("#request-title").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A title is required.</strong> Please type in a short title for your request.");
+    $("#request-description").attr("data-parsley-error-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A description is required.</strong> Please type in a detailed description of your request.");
+
     // Limit the size of the file upload to 20 Mb. Second parameter is number of Mb's.
     $("#request-file").attr("data-parsley-max-file-size", "20");
 

--- a/app/static/js/request/view-request-contact.js
+++ b/app/static/js/request/view-request-contact.js
@@ -14,18 +14,27 @@ $(document).ready(function () {
     subject.attr("data-parsley-required", "");
     message.attr("data-parsley-required", "");
 
-    firstName.attr('data-parsley-required-message', 'This information is required.');
-    lastName.attr('data-parsley-required-message', 'This information is required.');
-    email.attr('data-parsley-required-message', 'This information is required.');
-    subject.attr('data-parsley-required-message', 'This information is required.');
-    message.attr('data-parsley-required-message', 'This information is required.');
+    firstName.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>First name is required.</strong> Please type in your first name.");
+    lastName.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Last name is required.</strong> Please type in your last name.");
+    email.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An email name is required.</strong> Please type in your email.");
+    email.attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
+    subject.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A subject is required.</strong> Please type in a subject name.");
+    message.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A message is required.</strong> Please type in a message.");
 
     firstName.attr('data-parsley-maxlength', 32);
     lastName.attr('data-parsley-maxlength', 64);
     email.attr("data-parsley-maxlength", 254);
     message.attr('data-parsley-maxlength', 5000);
 
-    $("#contact-form").parsley();
+    $("#contact-form").parsley().on("form:validated", function () {
+        // Add tab index to any error messages
+        $(".parsley-required").each(function () {
+            $(this).attr("tabindex", 0);
+        });
+        $(".parsley-type").each(function () {
+            $(this).attr("tabindex", 0);
+        });
+    });
 
     firstName.keyup(function() {
         characterCounter("#first-name-character-count", 32, $(this).val().length)

--- a/app/static/js/request/view-request-contact.js
+++ b/app/static/js/request/view-request-contact.js
@@ -14,12 +14,24 @@ $(document).ready(function () {
     subject.attr("data-parsley-required", "");
     message.attr("data-parsley-required", "");
 
-    firstName.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>First name is required.</strong> Please type in your first name.");
-    lastName.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>Last name is required.</strong> Please type in your last name.");
-    email.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>An email name is required.</strong> Please type in your email.");
-    email.attr("data-parsley-type-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>This value should be an email.</strong> Please type in a valid email.");
-    subject.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A subject is required.</strong> Please type in a subject name.");
-    message.attr("data-parsley-required-message", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;<strong>A message is required.</strong> Please type in a message.");
+    firstName.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>First name is required.</strong> Please type in your first name.");
+    lastName.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>Last name is required.</strong> Please type in your last name.");
+    email.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>An email name is required.</strong> Please type in your email.");
+    email.attr("data-parsley-type-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>This value should be an email.</strong> Please type in a valid email.");
+    subject.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A subject is required.</strong> Please type in a subject name.");
+    message.attr("data-parsley-required-message",
+        "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+        "<strong>A message is required.</strong> Please type in a message.");
 
     firstName.attr('data-parsley-maxlength', 32);
     lastName.attr('data-parsley-maxlength', 64);

--- a/app/static/js/request/view-request-contact.js
+++ b/app/static/js/request/view-request-contact.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
         "<strong>This value should be an email.</strong> Please type in a valid email.");
     subject.attr("data-parsley-required-message",
         "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-        "<strong>A subject is required.</strong> Please type in a subject name.");
+        "<strong>A subject is required.</strong> Please type in a subject for your message.");
     message.attr("data-parsley-required-message",
         "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
         "<strong>A message is required.</strong> Please type in a message.");

--- a/app/static/js/validation/custom_validators.js
+++ b/app/static/js/validation/custom_validators.js
@@ -4,14 +4,14 @@
 
 "use strict";
 
-window.Parsley.addValidator('maxFileSize', {
+window.Parsley.addValidator("maxFileSize", {
   validateString: function(_value, maxSize, parsleyInstance) {
     var files = parsleyInstance.$element[0].files;
     return files.length != 1  || files[0].size <= maxSize * 1000000;
   },
-  requirementType: 'integer',
+  requirementType: "integer",
   messages: {
-    en: '<span class="glyphicon glyphicon-exclamation-sign"></span>&nbsp;' +
-    '<strong>The file cannot be larger than %s Mb.</strong> Please choose a smaller file.'
+    en: "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+    "<strong>The file cannot be larger than %s Mb.</strong> Please choose a smaller file."
   }
 });

--- a/app/static/js/validation/custom_validators.js
+++ b/app/static/js/validation/custom_validators.js
@@ -11,6 +11,7 @@ window.Parsley.addValidator('maxFileSize', {
   },
   requirementType: 'integer',
   messages: {
-    en: '<span class="glyphicon glyphicon-exclamation-sign"></span>&nbsp;<strong>The file cannot be larger than %s Mb.</strong> Please choose a smaller file.'
+    en: '<span class="glyphicon glyphicon-exclamation-sign"></span>&nbsp;' +
+    '<strong>The file cannot be larger than %s Mb.</strong> Please choose a smaller file.'
   }
 });

--- a/app/static/js/validation/custom_validators.js
+++ b/app/static/js/validation/custom_validators.js
@@ -11,6 +11,6 @@ window.Parsley.addValidator('maxFileSize', {
   },
   requirementType: 'integer',
   messages: {
-    en: 'The file cannot not be larger than %s Mb',
+    en: '<span class="glyphicon glyphicon-exclamation-sign"></span>&nbsp;<strong>The file cannot be larger than %s Mb.</strong> Please choose a smaller file.'
   }
 });

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -223,3 +223,8 @@ input[type="radio"], input[type="checkbox"] {
     margin-top: 10px;
     margin-bottom: 10px;
 }
+
+.parsley-errors-list.filled {
+    font-size: 14px;
+    color: #df0000;
+}

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -90,7 +90,7 @@
 
 .contact-form-error-message {
     /*color: indianred;*/
-    color: #e74c3c;
+    color: #df0000;
 }
 
 footer .form-search .input-search {

--- a/app/static/styles/new_request/new-request.css
+++ b/app/static/styles/new_request/new-request.css
@@ -30,6 +30,16 @@
     color: #e74c3c;
 }
 
+.parsley-custom-error-message {
+    font-size: 14px;
+    color: #df0000;
+}
+
+.parsley-length {
+    font-size: 14px;
+    color: #df0000;
+}
+
 #state {
     height: 50px;
 }

--- a/app/static/styles/new_request/new-request.css
+++ b/app/static/styles/new_request/new-request.css
@@ -30,16 +30,6 @@
     color: #e74c3c;
 }
 
-.parsley-custom-error-message {
-    font-size: 14px;
-    color: #df0000;
-}
-
-.parsley-length {
-    font-size: 14px;
-    color: #df0000;
-}
-
 #state {
     height: 50px;
 }

--- a/app/static/styles/new_request/new-request.css
+++ b/app/static/styles/new_request/new-request.css
@@ -173,3 +173,9 @@ input[type=text] .file-text-input {
     border-color: #4D90FE;
     outline: 2px solid transparent;
 }
+
+.parsley-maxFileSize {
+    font-size: 14px;
+    color: #df0000;
+    padding-bottom: 10px;
+}

--- a/app/templates/auth/manage_account.html
+++ b/app/templates/auth/manage_account.html
@@ -10,7 +10,7 @@
 
 <div id="container-fluid">
     <div class="col-sm-12">
-        <form method="post" class="form" role="form" id="request-form" data-parsley-validate>
+        <form method="post" class="form" role="form" id="request-form" data-parsley-validate data-parsley-focus="none">
             <h1 class="text-center">Manage OpenRecords Account
             <small data-toggle="popover"
                    data-placement="bottom"
@@ -49,7 +49,7 @@
                 maxlength="128") }}
             <p id="organization-character-count" class="character-counter">128 characters remaining</p>
             <br>
-            <div class="contact-form-error-message"></div>
+            <div class="contact-form-error-message" tabindex="0"></div>
 
             {{ form.notification_email.label(class='request-heading') }}
             <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Notification Email"

--- a/app/templates/custom_request_form_templates/date_template.html
+++ b/app/templates/custom_request_form_templates/date_template.html
@@ -1,5 +1,5 @@
 <div class="custom-request-form-date custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}{% if field_required %} (required){% endif %}</label>
     {% if tooltip %}
         <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
     {% endif %}

--- a/app/templates/custom_request_form_templates/input_template.html
+++ b/app/templates/custom_request_form_templates/input_template.html
@@ -1,5 +1,5 @@
 <div class="custom-request-form-input custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}{% if field_required %} (required){% endif %}</label>
     {% if tooltip %}
         <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
     {% endif %}

--- a/app/templates/custom_request_form_templates/radio_template.html
+++ b/app/templates/custom_request_form_templates/radio_template.html
@@ -1,5 +1,5 @@
 <div class="custom-request-form-radio custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}{% if field_required %} (required){% endif %}</label>
     {% if tooltip %}
         <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
     {% endif %}

--- a/app/templates/custom_request_form_templates/select_dropdown_template.html
+++ b/app/templates/custom_request_form_templates/select_dropdown_template.html
@@ -1,5 +1,5 @@
 <div class="custom-request-form-select-dropdown custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}{% if field_required %} (required){% endif %}</label>
     {% if tooltip %}
         <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
     {% endif %}

--- a/app/templates/custom_request_form_templates/select_multiple_template.html
+++ b/app/templates/custom_request_form_templates/select_multiple_template.html
@@ -1,5 +1,5 @@
 <div class="custom-request-form-select-multiple custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}{% if field_required %} (required){% endif %}</label>
     {% if tooltip %}
         <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
     {% endif %}

--- a/app/templates/custom_request_form_templates/textarea_template.html
+++ b/app/templates/custom_request_form_templates/textarea_template.html
@@ -1,5 +1,5 @@
 <div class="custom-request-form-textarea custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}{% if field_required %} (required){% endif %}</label>
     {% if tooltip %}
         <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
     {% endif %}

--- a/app/templates/custom_request_form_templates/time_template.html
+++ b/app/templates/custom_request_form_templates/time_template.html
@@ -1,5 +1,5 @@
 <div class="custom-request-form-time custom-request-form-field">
-    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}</label>
+    <label class="request-heading" for="{{ field_name }}-{{ instance_id }}">{{ field_text }}{% if field_required %} (required){% endif %}</label>
     {% if tooltip %}
         <span id="{{ field_name }}-{{ instance_id }}-tooltip" class="glyphicon glyphicon-question-sign"></span>
     {% endif %}

--- a/app/templates/main/contact.html
+++ b/app/templates/main/contact.html
@@ -13,7 +13,7 @@
             available within the actual request.</p>
         <br/>
         <div>
-            <form id="contact-info" action="{{ url_for('main.technical_support') }}" method="POST" role="form">
+            <form id="contact-info" action="{{ url_for('main.technical_support') }}" method="POST" role="form" data-parsley-focus="first">
 
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 

--- a/app/templates/request/_edit_requester_info.html
+++ b/app/templates/request/_edit_requester_info.html
@@ -17,13 +17,13 @@
                         aria-hidden="true">&times;</span></button>
                 <h4 class="modal-title">Requester Information</h4>
             </div>
-            <form id="user-info">
+            <form id="user-info" data-parsley-focus="none">
                 {{ edit_requester_form.csrf_token }}
 
                 <div class="modal-body">
                     {% set is_public_requester = request.requester.is_public %}
                     <div id="requester-name">{{ request.requester.name }}</div>
-                    <div class="contact-form-error-message"></div>
+                    <div class="contact-form-error-message" tabindex="0"></div>
                     {{ edit_requester_form.email.label }}
                     {{ edit_requester_form.email(id='inputEmail', type='email', class='form-control', maxlength="254",
                         readonly=is_public_requester) }}

--- a/app/templates/request/_view_request_contact_modal.html
+++ b/app/templates/request/_view_request_contact_modal.html
@@ -7,7 +7,8 @@
                 <h4 class="modal-title">Contact the Agency</h4>
             </div>
             <div class="modal-body">
-                <form id="contact-form" role="form" action="/request/contact/{{ request.id }}" method="POST">
+                <form id="contact-form" role="form" action="/request/contact/{{ request.id }}" method="POST"
+                    data-parsley-focus="first">
                     {{ contact_agency_form.csrf_token }}
 
                     {{ contact_agency_form.first_name.label }}

--- a/app/templates/request/new_request_agency.html
+++ b/app/templates/request/new_request_agency.html
@@ -112,6 +112,8 @@
                                     <strong class="modal-title">Confirm Delete</strong>
                                 </div>
                                 <div class="modal-body">
+                                    Are you sure you want to delete this form? All your entered
+                                    information will be lost.
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/app/templates/request/new_request_agency.html
+++ b/app/templates/request/new_request_agency.html
@@ -150,7 +150,7 @@
                 <div id="upload-control" class="col-sm-12">
                     {{ form.request_file.label(class="request-heading", for="request-file", tabindex=0) }}
                     <br>
-                    <div class="alert alert-danger file-error" hidden></div>
+                    <div class="file-error" hidden></div>
                     <label for="request-file" id="choose-file" aria-live="assertive">
                     <span id="choose-file-button" role="button" aria-controls="filename" tabindex="0">
                       Choose File

--- a/app/templates/request/new_request_agency.html
+++ b/app/templates/request/new_request_agency.html
@@ -15,7 +15,7 @@
     <div id="container-fluid">
         <div class="col-sm-10 col-sm-push-1" role="main">
             <form method="post" class="form new-request-agency" role="form" id="request-form" enctype=multipart/form-data
-                  data-parsley-validate>
+                  data-parsley-validate data-parsley-focus="first">
                 {{ form.csrf_token }}
 
                 <h1>Request a Record</h1>
@@ -150,7 +150,7 @@
                 <div id="upload-control" class="col-sm-12">
                     {{ form.request_file.label(class="request-heading", for="request-file", tabindex=0) }}
                     <br>
-                    <div class="file-error" hidden></div>
+                    <div class="file-error" tabindex="0" hidden></div>
                     <label for="request-file" id="choose-file" aria-live="assertive">
                     <span id="choose-file-button" role="button" aria-controls="filename" tabindex="0">
                       Choose File
@@ -199,7 +199,7 @@
                 {{ form.email(id="email", class="input-block-level",
                 placeholder="requester@email.com", maxlength="254") }}<br>
 
-                <div class="contact-form-error-message"></div>
+                <div class="contact-form-error-message" tabindex="0"></div>
                 <h2>Alternate Contact Information</h2>
 
                 <p>Fields are included in case alternate contact method is needed.</p>

--- a/app/templates/request/new_request_anon.html
+++ b/app/templates/request/new_request_anon.html
@@ -15,7 +15,7 @@
     <div id="container-fluid">
         <div class="col-sm-10 col-sm-push-1" role="main">
             <form method="post" class="form" role="form" id="request-form" enctype=multipart/form-data
-                  data-parsley-validate>
+                  data-parsley-validate data-parsley-focus="first">
                 {{ form.csrf_token }}
 
                 <h1>Request a Record</h1>

--- a/app/templates/request/new_request_anon.html
+++ b/app/templates/request/new_request_anon.html
@@ -146,7 +146,7 @@
                 <div id="upload-control" class="col-sm-12">
                     {{ form.request_file.label(class="request-heading", for="request-file", tabindex=0) }}
                     <br>
-                    <div class="file-error" hidden></div>
+                    <div class="file-error" tabindex="0" hidden></div>
                     <label for="request-file" id="choose-file" aria-live="assertive">
                     <span id="choose-file-button" role="button" aria-controls="filename" tabindex="0">
                       Choose File
@@ -182,7 +182,7 @@
                 {{ form.email(id="email", class="input-block-level",
                 placeholder="requester@email.com", maxlength="254") }}<br>
 
-                <div class="contact-form-error-message"></div>
+                <div class="contact-form-error-message" tabindex="0"></div>
 
                 <h2>Alternate Contact Information</h2>
 

--- a/app/templates/request/new_request_anon.html
+++ b/app/templates/request/new_request_anon.html
@@ -146,7 +146,7 @@
                 <div id="upload-control" class="col-sm-12">
                     {{ form.request_file.label(class="request-heading", for="request-file", tabindex=0) }}
                     <br>
-                    <div class="alert alert-danger file-error" hidden></div>
+                    <div class="file-error" hidden></div>
                     <label for="request-file" id="choose-file" aria-live="assertive">
                     <span id="choose-file-button" role="button" aria-controls="filename" tabindex="0">
                       Choose File

--- a/app/templates/request/new_request_anon.html
+++ b/app/templates/request/new_request_anon.html
@@ -108,6 +108,8 @@
                                     <strong class="modal-title">Confirm Delete</strong>
                                 </div>
                                 <div class="modal-body">
+                                    Are you sure you want to delete this form? All your entered
+                                    information will be lost.
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/app/templates/request/new_request_user.html
+++ b/app/templates/request/new_request_user.html
@@ -145,7 +145,7 @@
                 <div id="upload-control" class="col-sm-12">
                     {{ form.request_file.label(class="request-heading", for="request-file", tabindex=0) }}
                     <br>
-                    <div class="alert alert-danger file-error" hidden></div>
+                    <div class="file-error" hidden></div>
                     <label for="request-file" id="choose-file" aria-live="assertive">
                     <span id="choose-file-button" role="button" aria-controls="filename" tabindex="0">
                       Choose File

--- a/app/templates/request/new_request_user.html
+++ b/app/templates/request/new_request_user.html
@@ -107,6 +107,8 @@
                                     <strong class="modal-title">Confirm Delete</strong>
                                 </div>
                                 <div class="modal-body">
+                                    Are you sure you want to delete this form? All your entered
+                                    information will be lost.
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/app/templates/request/new_request_user.html
+++ b/app/templates/request/new_request_user.html
@@ -14,7 +14,7 @@
     <div id="container-fluid">
         <div class="col-sm-10 col-sm-push-1" role="main">
             <form method="post" class="form" role="form" id="request-form" enctype=multipart/form-data
-                  data-parsley-validate>
+                  data-parsley-validate data-parsley-focus="first">
                 {{ form.csrf_token }}
 
                 <h1>Request a Record</h1>
@@ -145,7 +145,7 @@
                 <div id="upload-control" class="col-sm-12">
                     {{ form.request_file.label(class="request-heading", for="request-file", tabindex=0) }}
                     <br>
-                    <div class="file-error" hidden></div>
+                    <div class="file-error" tabindex="0" hidden></div>
                     <label for="request-file" id="choose-file" aria-live="assertive">
                     <span id="choose-file-button" role="button" aria-controls="filename" tabindex="0">
                       Choose File

--- a/app/templates/response/add_acknowledgment.js.html
+++ b/app/templates/response/add_acknowledgment.js.html
@@ -58,16 +58,16 @@
         // Custom Validation Messages
         method.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Acknowledgement method is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Acknowledgement method is required.</strong> Please select an acknowledgment method from the drop-down menu.");
         email_days.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>This value is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Estimated time-frame for the request is required.</strong> Please select an estimated time-frame from the drop-down menu or choose a custom due date");
         letter_days.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>This value is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Estimated time-frame for the request is required.</strong> Please select an estimated time-frame from the drop-down menu or choose a custom due date.");
         letter_info.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>A template is required.</strong> Please select a template from the drop-down menu.");
 
         // Date Picker - Email
         holiday_dates = {{ holidays | safe }};

--- a/app/templates/response/add_acknowledgment.js.html
+++ b/app/templates/response/add_acknowledgment.js.html
@@ -55,6 +55,20 @@
             characterCounter("#acknowledgment-info-character-count", 5000, $(this).val().length);
         });
 
+        // Custom Validation Messages
+        method.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Acknowledgement method is required.</strong> Please select an option from the drop-down menu.");
+        email_days.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>This value is required.</strong> Please select an option from the drop-down menu.");
+        letter_days.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>This value is required.</strong> Please select an option from the drop-down menu.");
+        letter_info.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
+
         // Date Picker - Email
         holiday_dates = {{ holidays | safe }};
         email_date.datepicker({
@@ -80,8 +94,12 @@
                 email_date.parent().show();
                 email_info.attr("data-parsley-required", "");
                 email_info.attr("data-parsley-required-message",
-                    "This field is required when selecting a custom due date.");
+                    "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+                    "Additional information is required when selecting a custom due date.");
                 email_info.attr("data-parsley-minlength", "20");
+                email_info.attr("data-parsley-length-message",
+                    "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+                    "Additional information must have 20 characters or more.");
 
             } else {
                 email_date.parent().hide();

--- a/app/templates/response/add_closing.js.html
+++ b/app/templates/response/add_closing.js.html
@@ -56,13 +56,13 @@
         // Apply custom validation messages
         method.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Closing method is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Closing method is required.</strong> Please select a closing method from the drop-down menu.");
         reason_ids.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Closing reason is required.</strong> Please select an option.");
+            "<strong>Closing reason is required.</strong> Please select at least one closing reason from the multi-select field.");
         letter_info.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>A template is required.</strong> Please select a template from the drop-down menu.");
 
         next1.click(function (e) {
             method.parsley().validate();

--- a/app/templates/response/add_closing.js.html
+++ b/app/templates/response/add_closing.js.html
@@ -53,6 +53,17 @@
             required[i].attr("data-parsley-required", "");
         }
 
+        // Apply custom validation messages
+        method.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Closing method is required.</strong> Please select an option from the drop-down menu.");
+        reason_ids.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Closing reason is required.</strong> Please select an option.");
+        letter_info.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
+
         next1.click(function (e) {
             method.parsley().validate();
             if (!(method.parsley().isValid())) {

--- a/app/templates/response/add_denial.js.html
+++ b/app/templates/response/add_denial.js.html
@@ -53,6 +53,17 @@
             required[i].attr("data-parsley-required", "");
         }
 
+        // Custom Validation Messages
+        method.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Denial method is required.</strong> Please select an option from the drop-down menu.");
+        reason_ids.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>A denial reason is requred.</strong> Please select an option.");
+        letter_info.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>A template is requred.</strong> Please select an option from the drop-down-menu.");
+
         next1.click(function (e) {
             method.parsley().validate();
             if (!(method.parsley().isValid())) {

--- a/app/templates/response/add_denial.js.html
+++ b/app/templates/response/add_denial.js.html
@@ -56,13 +56,13 @@
         // Custom Validation Messages
         method.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Denial method is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Denial method is required.</strong> Please select a denial method from the drop-down menu.");
         reason_ids.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>A denial reason is requred.</strong> Please select an option.");
+            "<strong>A denial reason is requred.</strong> Please select at least one denial reason from the multi-select field.");
         letter_info.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>A template is requred.</strong> Please select an option from the drop-down-menu.");
+            "<strong>A template is requred.</strong> Please select a template from the drop-down-menu.");
 
         next1.click(function (e) {
             method.parsley().validate();

--- a/app/templates/response/add_extension.js.html
+++ b/app/templates/response/add_extension.js.html
@@ -273,26 +273,45 @@
         $("#custom-extension-letter").keydown(false);
 
         // Loop through required fields and apply a data-parsley-required attribute to them
-        var required_fields = ['custom-extension','custom-extension-letter', 'extension-select',
-                               'extension-select-letter', 'extension-reason', 'extension-method'];
+        var required_fields = ["custom-extension","custom-extension-letter", "extension-select",
+                               "extension-select-letter", "extension-reason", "extension-method"];
         for (var i = 0; i < required_fields.length; i++) {
-            $('#' + required_fields[i]).attr('data-parsley-required', '');
+            $("#" + required_fields[i]).attr("data-parsley-required", "");
         }
 
         // Apply parsley minimum length validation to extension reason
-        $('#extension-reason').attr('data-parsley-minlength', '20');
-        $('#extension-reason').attr('data-parsley-maxlength', '5000');
+        $("#extension-reason").attr("data-parsley-minlength", "20");
+        $("#extension-reason").attr("data-parsley-maxlength", "5000");
 
         // Apply parsley minimum length validation to extension reason
-        $('#extension-reason').attr('data-parsley-minlength','20');
-        $('#extension-reason').attr('data-parsley-maxlength','5000');
+        $("#extension-reason").attr("data-parsley-minlength","20");
+        $("#extension-reason").attr("data-parsley-maxlength","5000");
 
         // Apply custom validation messages
-        $('#custom-extension').attr('data-parsley-required-message', 'Extension date must be chosen');
-        $('#extension-select').attr('data-parsley-required-message', 'Extension length must be selected');
-        $('#custom-extension-letter').attr('data-parsley-required-message', 'Extension date must be chosen');
-        $('#extension-select-letter').attr('data-parsley-required-message', 'Extension length must be selected');
-        $('#extension-reason').attr('data-parsley-minlength-message', 'Extension reason must be at least 20 characters');
+        method.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Extension method is required.</strong> Please select an option from the drop-down menu.");
+        letter_info.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
+        $("#custom-extension").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Extension date must be chosen.</strong>");
+        $("#extension-select").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Extension length is required. Please select an option from the drop-down menu.</strong>");
+        $("#extension-reason").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Extension reason is required.</strong> Please type in a reason.");
+        $("#custom-extension-letter").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Extension date must be chosen.</strong>");
+        $("#extension-select-letter").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Extension length must be selected.</strong>");
+        $("#extension-reason").attr("data-parsley-minlength-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Extension reason must be at least 20 characters.</strong>");
 
         // Set character counter for extension reason
         $("#extension-reason").keyup(function () {

--- a/app/templates/response/add_extension.js.html
+++ b/app/templates/response/add_extension.js.html
@@ -290,16 +290,16 @@
         // Apply custom validation messages
         method.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Extension method is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Extension method is required.</strong> Please select an extension method from the drop-down menu.");
         letter_info.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>A template is required.</strong> Please select a template from the drop-down menu.");
         $("#custom-extension").attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
             "<strong>Extension date must be chosen.</strong>");
         $("#extension-select").attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Extension length is required. Please select an option from the drop-down menu.</strong>");
+            "<strong>Extension duration is required. Please select an extension duration from the drop-down menu.</strong>");
         $("#extension-reason").attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
             "<strong>Extension reason is required.</strong> Please type in a reason.");

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -52,7 +52,8 @@
 
             // Prevent default if no file has been added or uploaded
             if (templateDownload.length === 0 && (templateUpload.length === 0)) {
-                errorMessage.text("A file must be added").show();
+                errorMessage.html("<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+                    "<strong>A file is required.</strong> Please select a file.").show();
                 e.preventDefault();
                 return false;
             }

--- a/app/templates/response/add_instruction.js.html
+++ b/app/templates/response/add_instruction.js.html
@@ -81,14 +81,18 @@
         });
 
         // Apply parsley data required validation to instruction title and url
-        $('#instruction-content').attr('data-parsley-required', '');
+        $("#instruction-content").attr("data-parsley-required", "");
 
         // Apply parsley max length validation to instruction title and url
-        $('#instruction-content').attr('data-parsley-maxlength', '500');
+        $("#instruction-content").attr("data-parsley-maxlength", "500");
 
         // Apply custom validation messages
-        $('#instruction-content').attr('data-parsley-required-message', 'Offline Instructions must be provided');
-        $('#instruction-content').attr('data-parsley-maxlength-message', 'Offline Instructions must be less than 500 characters');
+        $("#instruction-content").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Offline Instructions are required.</strong> Please type in some instructions.");
+        $("#instruction-content").attr("data-parsley-maxlength-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "Offline Instructions must be less than 500 characters.");
 
         // Set character counter for instruction content
         $("#instruction-content").keyup(function () {

--- a/app/templates/response/add_link.js.html
+++ b/app/templates/response/add_link.js.html
@@ -80,32 +80,41 @@
         });
 
         // Apply parsley data required validation to link title and url
-        $('#link-title').attr('data-parsley-required', '');
-        $('#link-url').attr('data-parsley-required', '');
+        $("#link-title").attr("data-parsley-required", "");
+        $("#link-url").attr("data-parsley-required", "");
 
         // Apply parsley max length validation to link title and url
-        $('#link-title').attr('data-parsley-maxlength', '90');
-        $('#link-url').attr('data-parsley-maxlength', '254');
+        $("#link-title").attr("data-parsley-maxlength", "90");
+        $("#link-url").attr("data-parsley-maxlength", "254");
 
         // Apply custom validation messages
-        $('#link-title').attr('data-parsley-required-message', 'Link title must be provided.');
-        $('#link-url').attr('data-parsley-required-message', 'URL link must be provided.');
-        $('#link-title').attr('data-parsley-maxlength-message', 'Link title must be less than 90 characters.');
-        $('#link-url').attr('data-parsley-maxlength-message', 'URL link must be less than 254 characters.');
+        $("#link-title").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Link title is required.</strong> Please type in a title.");
+        $("#link-url").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>URL link is required.</strong> Please type in a link.");
+        $("#link-title").attr("data-parsley-maxlength-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "Link title must be less than 90 characters.");
+        $("#link-url").attr("data-parsley-maxlength-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "URL link must be less than 254 characters.");
 
         // Custom validator to validate strict url using regexUrlChecker
-        $('#link-url').attr('data-parsley-urlstrict', '');
-        window.Parsley.addValidator('urlstrict', function (value) {
-            return '' !== value ? regexUrlChecker(value) : false;
-        }).addMessage('en', 'urlstrict', 'This value should be a valid url.');
+        $("#link-url").attr("data-parsley-urlstrict", "");
+        window.Parsley.addValidator("urlstrict", function (value) {
+            return "" !== value ? regexUrlChecker(value) : false;
+        }).addMessage("en", "urlstrict", "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>This URL is invalid.</strong> Please type in a valid URL.");
 
         // Set character counter for link title
-        $('#link-title').keyup(function () {
+        $("#link-title").keyup(function () {
             characterCounter("#link-title-character-count", 90, $(this).val().length)
         });
 
         // Set character counter for link url
-        $('#link-url').keyup(function () {
+        $("#link-url").keyup(function () {
             characterCounter("#link-url-character-count", 254, $(this).val().length)
         });
     });

--- a/app/templates/response/add_link.js.html
+++ b/app/templates/response/add_link.js.html
@@ -90,7 +90,7 @@
         // Apply custom validation messages
         $("#link-title").attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Link title is required.</strong> Please type in a title.");
+            "<strong>Link title is required.</strong> Please type in a link title.");
         $("#link-url").attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
             "<strong>URL link is required.</strong> Please type in a link.");

--- a/app/templates/response/add_note.js.html
+++ b/app/templates/response/add_note.js.html
@@ -81,14 +81,18 @@
         });
 
         // Apply parsley data required validation to note title and url
-        $('#note-content').attr('data-parsley-required', '');
+        $("#note-content").attr("data-parsley-required", "");
 
         // Apply parsley max length validation to note title and url
-        $('#note-content').attr('data-parsley-maxlength', '5000');
+        $("#note-content").attr("data-parsley-maxlength", "5000");
 
         // Apply custom validation messages
-        $('#note-content').attr('data-parsley-required-message', 'Note content must be provided');
-        $('#note-content').attr('data-parsley-maxlength-message', 'Note content must be less than 5000 characters');
+        $("#note-content").attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Note content is required.</strong> Please type in a message.");
+        $("#note-content").attr("data-parsley-maxlength-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Note content must be less than 5000 characters</strong>");
 
         // Set character counter for note content
         $("#note-content").keyup(function () {

--- a/app/templates/response/add_reopening.js.html
+++ b/app/templates/response/add_reopening.js.html
@@ -30,13 +30,13 @@
         // Apply custom validation messages
         method.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Closing method is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Re-opening method is required.</strong> Please select a re-opening method from the drop-down menu.");
         date.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
             "<strong>New due date is required.</strong> Please select a date using the date picker.");
         letter_template.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>Template is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>Template is required.</strong> Please select a letter template from the drop-down menu.");
 
         // Setup the reason dropdown
 

--- a/app/templates/response/add_reopening.js.html
+++ b/app/templates/response/add_reopening.js.html
@@ -27,6 +27,17 @@
         method.attr("data-parsley-required", "");
         date.attr("data-parsley-required", "");
 
+        // Apply custom validation messages
+        method.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Closing method is required.</strong> Please select an option from the drop-down menu.");
+        date.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>New due date is required.</strong> Please select a date using the date picker.");
+        letter_template.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Template is required.</strong> Please select an option from the drop-down menu.");
+
         // Setup the reason dropdown
 
         reason_group.show();

--- a/app/templates/response/generate_envelope.js.html
+++ b/app/templates/response/generate_envelope.js.html
@@ -18,6 +18,23 @@
         state.attr("data-parsley-required", "");
         zipcode.attr("data-parsley-required", "");
 
+        // Custom Validation Messages
+        recipient_name.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Recipient name is required.</strong> Please type in a name.");
+        address_one.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Address is required.</strong> Please type in an address.");
+        city.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>City is required.</strong> Please type in a city.");
+        state.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>State is required.</strong> Please type in a state.");
+        zipcode.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>Zipcode is required.</strong> Please type in a zipcode.");
+
         form.submit(function () {
             submit.attr("disabled", true);
         });

--- a/app/templates/response/generate_letter.js.html
+++ b/app/templates/response/generate_letter.js.html
@@ -17,7 +17,9 @@
         var letter_template_id = first.find("#letter-template-id");
 
         // Parsley
-        letter_template_id.attr("data-parsley-required", "");
+        letter_template_id.attr("data-parsley-required-message",
+            "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
+            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
 
         next1.click(function (e) {
             letter_template_id.parsley().validate();

--- a/app/templates/response/generate_letter.js.html
+++ b/app/templates/response/generate_letter.js.html
@@ -19,7 +19,7 @@
         // Parsley
         letter_template_id.attr("data-parsley-required-message",
             "<span class=\"glyphicon glyphicon-exclamation-sign\"></span>&nbsp;" +
-            "<strong>A template is required.</strong> Please select an option from the drop-down menu.");
+            "<strong>A template is required.</strong> Please select a template from the drop-down menu.");
 
         next1.click(function (e) {
             letter_template_id.parsley().validate();

--- a/data/custom_request_forms.json
+++ b/data/custom_request_forms.json
@@ -9,7 +9,7 @@
           "Arrest Report #": {
             "type": "input",
             "name": "arrest-report-number",
-            "required": false,
+            "required": true,
             "placeholder": "123456789",
             "max_length": "50",
             "character_counter": true,
@@ -20,7 +20,8 @@
             "tooltip": {
               "title": "Arrest report number tooltip title",
               "content": "Arrest report number tooltip content"
-            }
+            },
+            "error_message": "<strong>Arrest Report Number is required.</strong> Please type in a number."
           }
         },
         {


### PR DESCRIPTION
This PR updates the parsley error validation to be more accessible and 508 compliant on the public facing side of the application.

Primary changes that have been made:
- Updated all error messages to be more descriptive. Instead of just saying something like `This value is required`, most messages will have 2 parts. What is the error and how to fix the error.
ex: Request title is required. Please type in a title.
- Error message text color has been changed to meet the color contrast ratio test. The first part of the error message has been bolded to place emphasis on the error.
- Added tab index to all error messages so that they are tabbed through.
- When a form fails validation, the first field with an error will gain keyboard focus.
- Added custom error messages to custom request form fields that are required. Add the property `error_message` to the custom request forms JSON to use it. Ex) `"error_message": "<strong>Arrest Report Number is required.</strong> Please type in a number."`

I also updated all the error message text/color/styles for the agency facing side of the application but some of the screen reader navigation has been left out for now. We need to have another evaluation of what design changes need to be made first. As it stands I feel like the agency side of the application has too much content to be easily navigable. 

