### PR TITLE
Feature/OP-1473: FAQ Accessibility

### DIFF
--- a/app/static/js/request/faq.js
+++ b/app/static/js/request/faq.js
@@ -1,0 +1,25 @@
+"use strict";
+
+
+function generate_faq_click_handler(id) {
+    /*
+     * This function creates faq link click handlers for when you have multiple events inside a loop
+     */
+    return function (e) {
+        e.preventDefault();
+        $(window).scrollTop($("#faq-answer-" + id).offset().top - 50);
+        $("#faq-answer-" + id).focus();
+    };
+}
+
+$(document).ready(function () {
+    // Focus on FAQ header when Back to Top is clicked
+    $(".back-to-top").click(function () {
+        $("#faq-header").focus();
+    });
+
+    // Create handlers to focus on the FAQ answer paragraph when the link is clicked
+    $(".faq-link").each(function (index) {
+        $("#" + this.id).click(generate_faq_click_handler(index + 1));
+    });
+});

--- a/app/static/js/request/faq.js
+++ b/app/static/js/request/faq.js
@@ -1,7 +1,7 @@
 "use strict";
 
 
-function generate_faq_click_handler(id) {
+function generateFaqClickHandler(id) {
     /*
      * This function creates faq link click handlers for when you have multiple events inside a loop
      */
@@ -20,6 +20,6 @@ $(document).ready(function () {
 
     // Create handlers to focus on the FAQ answer paragraph when the link is clicked
     $(".faq-link").each(function (index) {
-        $("#" + this.id).click(generate_faq_click_handler(index + 1));
+        $("#" + this.id).click(generateFaqClickHandler(index + 1));
     });
 });

--- a/app/static/js/request/main.js
+++ b/app/static/js/request/main.js
@@ -48,7 +48,7 @@ function characterCounter(target, maxLength, currentLength, minLength) {
     }
 }
 
-function generate_character_counter_handler(id, maxLength, minLength) {
+function generateCharacterCounterHandler(id, maxLength, minLength) {
     /*
      * This function creates character counter handlers for when you have multiple events inside a loop
      */
@@ -543,7 +543,7 @@ function renderCustomRequestForm(target) {
                 // initialize character counters in custom forms
                 for (var id in data["character_counters"]) {
                     $("#" + id).keyup(
-                        generate_character_counter_handler(id, data["character_counters"][id]["max_length"], data["character_counters"][id]["min_length"])
+                        generateCharacterCounterHandler(id, data["character_counters"][id]["max_length"], data["character_counters"][id]["min_length"])
                     );
                 }
 

--- a/app/static/styles/faq.css
+++ b/app/static/styles/faq.css
@@ -9,3 +9,7 @@
 .faq-question {
     font-size: 18px;
 }
+
+.faq-answer {
+    margin-bottom: 0;
+}

--- a/app/templates/main/faq.html
+++ b/app/templates/main/faq.html
@@ -9,141 +9,128 @@
 {% block content %}
     <div class="container-fluid" role="main">
 
-        <h1 class="text-center" id="faq-header">Frequently Asked Questions</h1>
-        <a class="faq-link" href="#faq-one">What does FOIL mean?</a><br>
-        <a class="faq-link" href="#faq-two">What kinds of records do I have the right to see?</a><br>
-        <a class="faq-link" href="#faq-three">Are there any public records that I can’t see?</a><br>
-        <a class="faq-link" href="#faq-four">Do I have to explain why I want the records?</a><br>
-        <a class="faq-link" href="#faq-five">How much does it cost to get access to government records?</a><br>
-        <a class="faq-link" href="#faq-six">How long does it take to get access to government records?</a><br>
-        <a class="faq-link" href="#faq-seven">Can I make an anonymous request?</a><br>
-        <a class="faq-link" href="#faq-eight">How do I know which agency handles the records I need?</a><br>
-        <a class="faq-link" href="#faq-nine">How do I make a request?</a><br>
-        <a class="faq-link" href="#faq-ten">I asked for a copy of public records and the agency refused my request, saying that
+        <h1 class="text-center" id="faq-header" tabindex="-1">Frequently Asked Questions</h1>
+        <a class="faq-link" id="faq-link-1" href="#faq-1">What does FOIL mean?</a><br>
+        <a class="faq-link" id="faq-link-2" href="#faq-2">What kinds of records do I have the right to see?</a><br>
+        <a class="faq-link" id="faq-link-3" href="#faq-3">Are there any public records that I can’t see?</a><br>
+        <a class="faq-link" id="faq-link-4" href="#faq-4">Do I have to explain why I want the records?</a><br>
+        <a class="faq-link" id="faq-link-5" href="#faq-5">How much does it cost to get access to government records?</a><br>
+        <a class="faq-link" id="faq-link-6" href="#faq-6">How long does it take to get access to government records?</a><br>
+        <a class="faq-link" id="faq-link-7" href="#faq-7">Can I make an anonymous request?</a><br>
+        <a class="faq-link" id="faq-link-8" href="#faq-8">How do I know which agency handles the records I need?</a><br>
+        <a class="faq-link" id="faq-link-9" href="#faq-9">How do I make a request?</a><br>
+        <a class="faq-link" id="faq-link-10" href="#faq-10">I asked for a copy of public records and the agency refused my request, saying that
             it was too broad. What can I do?</a><br>
-        <a class="faq-link" href="#faq-eleven">How do I track a request?</a><br>
-        <a class="faq-link" href="#faq-twelve">What if I have multiple requests that I want to track or would like to see what other
+        <a class="faq-link" id="faq-link-11" href="#faq-11">How do I track a request?</a><br>
+        <a class="faq-link" id="faq-link-12" href="#faq-12">What if I have multiple requests that I want to track or would like to see what other
             requests have been submitted?</a><br>
-        <a class="faq-link" href="#faq-thirteen">What if I don’t agree with an agency’s response?</a>
+        <a class="faq-link" id="faq-link-13" href="#faq-13">What if I don’t agree with an agency’s response?</a>
         <br><br>
 
-        <h2 class="faq-question" id="faq-one">What does FOIL mean?</h2>
-
-        <p>FOIL stands for the Freedom of Information Law. The New York State Freedom of Information Law
+        <h2 class="faq-question" id="faq-1">What does FOIL mean?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-1">FOIL stands for the Freedom of Information Law. The New York State Freedom of Information Law
             requires government agencies to provide records to the public upon request. Government records
             affect the lives of each New Yorker, and providing easy access to the records makes government work
-            better.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            better.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-two">What kinds of records do I have the right to see?</h2>
-
-        <p>The FOIL definition of records is very broad and includes information found in paper and electronic
+        <h2 class="faq-question" id="faq-2">What kinds of records do I have the right to see?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-2">The FOIL definition of records is very broad and includes information found in paper and electronic
             documents and audio and visual recordings. All records are available upon request, unless an
-            exception in FOIL permits an agency to deny access to a record.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            exception in FOIL permits an agency to deny access to a record.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-three">Are there any public records that I can’t see?</h2>
-
-        <p>Yes, there are exceptions in FOIL. Most of the exceptions are based upon common sense and the
+        <h2 class="faq-question" id="faq-3">Are there any public records that I can’t see?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-3">Yes, there are exceptions in FOIL. Most of the exceptions are based upon common sense and the
             potential for harm that would arise if the contents of the record were disclosed to unauthorized
             people. If disclosure of a record would be damaging to an individual or prevent a government agency
             from carrying out its duties, it is likely that some or all of the record may be withheld. You can
             read the law, including the exceptions, by clicking here. <a
-                    href="https://law.justia.com/codes/new-york/2015/pbo/article-6/87/">See FOIL &sect;87(2)</a>
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+                    href="https://law.justia.com/codes/new-york/2015/pbo/article-6/87/">See FOIL &sect;87(2)</a></p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-four">Do I have to explain why I want the records?</h2>
+        <h2 class="faq-question" id="faq-4">Do I have to explain why I want the records?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-4">No, unless you are a business or other organization that is requesting a list of names and
+            addresses.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <p>No, unless you are a business or other organization that is requesting a list of names and
-            addresses.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
-
-        <h2 class="faq-question" id="faq-five">How much does it cost to get access to government records?</h2>
-
-        <p>There is no charge to submit a FOIL request or to look at records in the office of an agency.
+        <h2 class="faq-question" id="faq-5">How much does it cost to get access to government records?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-5">There is no charge to submit a FOIL request or to look at records in the office of an agency.
             However, you may be charged by an agency for the cost of reproducing the records you requested. FOIL
-            limits the amount that can be charged.</p>
-        <p>You may always include in your request letter a specific statement limiting the amount that you are
+            limits the amount that can be charged.
+            <br><br>
+            You may always include in your request letter a specific statement limiting the amount that you are
             willing to pay. If an agency estimates that the total cost will exceed that amount, you may narrow
-            your request in order to reduce the cost.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            your request in order to reduce the cost.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-six">How long does it take to get access to government records?</h2>
-        <p>The agency will acknowledge your request within five (5) business days of receiving it. The actual
+        <h2 class="faq-question" id="faq-6">How long does it take to get access to government records?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-6">The agency will acknowledge your request within five (5) business days of receiving it. The actual
             time to complete a request will vary depending on many factors, such as the number of records
             requested and the difficulty involved in locating and reviewing the records. You will be notified of
-            the amount of time the agency needs to complete your request.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            the amount of time the agency needs to complete your request.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-seven">Can I make an anonymous request?</h2>
-        <p>On the OpenRecords portal, your name will not be viewable by the public. The topic of the request
-            will be shown.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+        <h2 class="faq-question" id="faq-7">Can I make an anonymous request?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-7">On the OpenRecords portal, your name will not be viewable by the public. The topic of the request
+            will be shown.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-eight">How do I know which agency handles the records I need?</h2>
-        <p>The OpenRecords portal has a field named “categories” that will help you identify the correct agency.
+        <h2 class="faq-question" id="faq-8">How do I know which agency handles the records I need?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-8">The OpenRecords portal has a field named “categories” that will help you identify the correct agency.
             When you choose one of the categories, the list of possible agencies will be narrowed to those that
             may have the records you want. You can select the agency from the list provided to start the FOIL
             request process. If you submit a records request to the wrong agency, you will be notified within
-            five days that the request should be resubmitted to a different agency.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            five days that the request should be resubmitted to a different agency.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-nine">How do I make a request?</h2>
-        <p>You can submit a FOIL request at the OpenRecords portal for all NYC agencies. Visit <a
+        <h2 class="faq-question" id="faq-9">How do I make a request?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-9">You can submit a FOIL request at the OpenRecords portal for all NYC agencies. Visit <a
                 href="{{ url_for('request.new') }}">{{ request.url_root }}request/new</a> and follow
-            the prompts and directions provided in order to make your request.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            the prompts and directions provided in order to make your request.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-ten">I asked for a copy of public records and the agency refused my request, saying that
+        <h2 class="faq-question" id="faq-10">I asked for a copy of public records and the agency refused my request, saying that
             it was too broad. What can I do?</h2>
-        <p>An agency may deny a request that does not "reasonably describe" records. If the request is too
+        <p class="faq-answer" tabindex="-1" id="faq-answer-10">An agency may deny a request that does not "reasonably describe" records. If the request is too
             vague, the agency may ask for clarification. You may then submit a new request with a more specific
-            description of the records you would like.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            description of the records you would like.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-eleven">How do I track a request?</h2>
-        <p>After your request has been submitted, a message will display verifying the submission and providing
+        <h2 class="faq-question" id="faq-11">How do I track a request?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-11">After your request has been submitted, a message will display verifying the submission and providing
             a request number. Select Search Requests from the top menu and enter your request number,
-            then press the Search button. The status of your request will be displayed.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            then press the Search button. The status of your request will be displayed.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-twelve">What if I have multiple requests that I want to track or would like to see what other
+        <h2 class="faq-question" id="faq-12">What if I have multiple requests that I want to track or would like to see what other
             requests have been submitted?</h2>
-        <p>Select View Requests from the top menu. You can then search existing requests using text from the
-            request, the current status, the date range and the agency.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-12">Select View Requests from the top menu. You can then search existing requests using text from the
+            request, the current status, the date range and the agency.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
 
-        <h2 class="faq-question" id="faq-thirteen">What if I don’t agree with an agency’s response?</h2>
-        <p>You may appeal a decision to deny your request within 30 days of receiving the denial or partial
+        <h2 class="faq-question" id="faq-13">What if I don’t agree with an agency’s response?</h2>
+        <p class="faq-answer" tabindex="-1" id="faq-answer-13">You may appeal a decision to deny your request within 30 days of receiving the denial or partial
             denial. The denial or partial denial should provide the contact information for the Agency Appeals
             Officer. Your appeal letter should state the reason you are appealing and why the agency's response
-            to the request was improper.
-            <br/>
-            <a href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a></p>
-        <br>
+            to the request was improper.</p>
+        <a class="back-to-top" href="#"><span class="glyphicon glyphicon-chevron-up"></span>Back to top</a>
+        <br><br>
     </div>
+{% endblock %}
+
+{% block custom_script %}
+    <script type="text/javascript" src="{{ url_for('static', filename='js/request/faq.js') }}"></script>
 {% endblock %}

--- a/tests/functional/test_main.py
+++ b/tests/functional/test_main.py
@@ -183,7 +183,7 @@ def test_faq(
     """
     response = client.get('/faq')
     assert response.status_code == 200
-    assert b'<h1 class="text-center" id="faq-header">Frequently Asked Questions</h1>' in response.data
+    assert b'<h1 class="text-center" id="faq-header" tabindex="-1">Frequently Asked Questions</h1>' in response.data
 
 
 def test_about(


### PR DESCRIPTION
Main changes that happened in this PR:
- Clicking each FAQ link will scroll to the answer and give keyboard focus to the answer so the screen reader reads it.
- Clicking Back to Top will scroll up and give keyboard focus to the Frequent Asked Questions header.