### PR TITLE
Bugfix/OP-1601: Emails Not Being Generated If AJAX Doesn't Finish

### DIFF
--- a/app/response/views.py
+++ b/app/response/views.py
@@ -347,7 +347,7 @@ def response_extension(request_id):
     # TODO: Get copy from business, insert sentry issue key in message
     # Error handling to check if retrieved elements exist. Flash error message if elements does not exist.
     for field in required_fields:
-        if extension_data.get(field) is None:
+        if not extension_data.get(field, ''):
             flash('Uh Oh, it looks like the extension {} is missing! '
                   'This is probably NOT your fault.'.format(field), category='danger')
             return redirect(url_for('request.view', request_id=request_id))
@@ -387,7 +387,7 @@ def response_link(request_id):
     # TODO: Get copy from business, insert sentry issue key in message
     # Error handling to check if retrieved elements exist. Flash error message if elements does not exist.
     for field in required_fields:
-        if link_data.get(field) is None:
+        if not link_data.get(field, ''):
             flash('Uh Oh, it looks like the link {} is missing! '
                   'This is probably NOT your fault.'.format(field), category='danger')
             return redirect(url_for('request.view', request_id=request_id))
@@ -423,7 +423,7 @@ def response_instructions(request_id):
     # TODO: Get copy from business, insert sentry issue key in message
     # Error handling to check if retrieved elements exist. Flash error message if elements does not exist.
     for field in required_fields:
-        if instruction_data.get(field) is None:
+        if not instruction_data.get(field, ''):
             flash('Uh Oh, it looks like the instruction {} is missing! '
                   'This is probably NOT your fault.'.format(field), category='danger')
             return redirect(url_for('request.view', request_id=request_id))
@@ -510,8 +510,6 @@ def response_email():
         "error": "No changes detected."
     }
     """
-    import time
-    time.sleep(2)
     data = flask_request.form
     request_id = data['request_id']
 

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -222,7 +222,7 @@ def response_denial(request_id):
                            'method',
                            'summary']
     for field in required_fields:
-        if flask_request.form.get(field) is None:
+        if not flask_request.form.get(field, ''):
             flash('Uh Oh, it looks like the denial {} is missing! '
                   'This is probably NOT your fault.'.format(field), category='danger')
             return redirect(url_for('request.view', request_id=request_id))
@@ -510,6 +510,8 @@ def response_email():
         "error": "No changes detected."
     }
     """
+    import time
+    time.sleep(2)
     data = flask_request.form
     request_id = data['request_id']
 

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -256,7 +256,7 @@ def response_closing(request_id):
                            'method',
                            'summary']
     for field in required_fields:
-        if flask_request.form.get(field) is None:
+        if not flask_request.form.get(field, ''):
             flash('Uh Oh, it looks like the closing {} is missing! '
                   'This is probably NOT your fault.'.format(field), category='danger')
             return redirect(url_for('request.view', request_id=request_id))

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -112,8 +112,8 @@ def response_note(request_id):
     # TODO: Get copy from business, insert sentry issue key in message
     # Error handling to check if retrieved elements exist. Flash error message if elements does not exist.
     for field in required_fields:
-        if note_data.get(field) is None:
-            flash('Uh Oh, it looks like the instruction {} is missing! '
+        if not note_data.get(field, ''):
+            flash('Uh Oh, it looks like the note {} is missing! '
                   'This is probably NOT your fault.'.format(field), category='danger')
             return redirect(url_for('request.view', request_id=request_id))
 

--- a/app/static/styles/add_acknowledgment.css
+++ b/app/static/styles/add_acknowledgment.css
@@ -1,4 +1,0 @@
-.summary{
-    overflow-y: auto;
-    padding-bottom: 5px;
-}

--- a/app/static/styles/add_closing.css
+++ b/app/static/styles/add_closing.css
@@ -1,6 +1,0 @@
-.summary{
-    overflow-y: auto;
-    padding-bottom: 5px;
-    min-height: 100px;
-    margin-bottom: 10px;
-}

--- a/app/static/styles/add_closing.css
+++ b/app/static/styles/add_closing.css
@@ -1,4 +1,5 @@
 .summary{
     overflow-y: auto;
     padding-bottom: 5px;
+    min-height: 250px;
 }

--- a/app/static/styles/add_closing.css
+++ b/app/static/styles/add_closing.css
@@ -1,5 +1,6 @@
 .summary{
     overflow-y: auto;
     padding-bottom: 5px;
-    min-height: 250px;
+    min-height: 100px;
+    margin-bottom: 10px;
 }

--- a/app/static/styles/add_denial.css
+++ b/app/static/styles/add_denial.css
@@ -1,4 +1,0 @@
-.summary{
-    overflow-y: auto;
-    padding-bottom: 5px;
-}

--- a/app/static/styles/add_extension.css
+++ b/app/static/styles/add_extension.css
@@ -14,8 +14,3 @@
 #extension-reason {
     height: 10rem;
 }
-
-.summary{
-    overflow-y: auto;
-    padding-bottom: 5px;
-}

--- a/app/static/styles/view_request.css
+++ b/app/static/styles/view_request.css
@@ -117,3 +117,10 @@
         transform: rotate(360deg);
     }
 }
+
+.summary {
+    overflow-y: auto;
+    padding-bottom: 5px;
+    min-height: 100px;
+    margin-bottom: 10px;
+}

--- a/app/templates/request/view_request.html
+++ b/app/templates/request/view_request.html
@@ -19,9 +19,6 @@
     <link rel=stylesheet type=text/css href="{{ url_for('static', filename='styles/add_link.css') }}"/>
     <link rel=stylesheet type=text/css href="{{ url_for('static', filename='styles/add_note.css') }}"/>
     <link rel=stylesheet type=text/css href="{{ url_for('static', filename='styles/add_instruction.css') }}"/>
-    <link rel=stylesheet type=text/css href="{{ url_for('static', filename='styles/add_acknowledgment.css') }}"/>
-    <link rel=stylesheet type=text/css href="{{ url_for('static', filename='styles/add_denial.css') }}"/>
-    <link rel=stylesheet type=text/css href="{{ url_for('static', filename='styles/add_closing.css') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/app/templates/response/add_acknowledgment.html
+++ b/app/templates/response/add_acknowledgment.html
@@ -87,7 +87,7 @@
             </div>
             <div class="third" hidden>
                 <h4 id="edit-body-header">Edit Email Body</h4>
-                <div class="form-group">
+                <div id="acknowledgment-editor" class="form-group">
                     <div class="email-content-hidden" hidden></div>
                     <textarea title="acknowledgment-body" name="acknowledgment-body"
                               class="tinymce-area"></textarea>
@@ -97,7 +97,7 @@
             </div>
             <div class="fourth" hidden>
                 <h4 class="confirmation-header"></h4>
-                <div class="wrap-text summary"></div>
+                <div id="acknowledgment-confirmation" class="wrap-text summary"></div>
                 <input type="hidden" name="summary">
                 <input type="hidden" name="tz-name">
                 <button type="button" class="prev pull-left btn btn-default">Prev</button>

--- a/app/templates/response/add_acknowledgment.js.html
+++ b/app/templates/response/add_acknowledgment.js.html
@@ -33,6 +33,9 @@
 
         var edit_body_header = third.find('#edit-body-header');
 
+        var editor = $("#acknowledgment-editor");
+        var confirmation = $("#acknowledgment-confirmation");
+
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {
             first.show();
@@ -192,6 +195,8 @@
                             emailContent.html(data.template);
                             flask_moment_render_all();
                             tinyMCE.get("acknowledgment-body").setContent(emailContent.html());
+                            editor.unblock();
+                            next3.prop('disabled', false);
                         }
                     });
 
@@ -219,6 +224,8 @@
                             emailContent.html(data.template);
                             flask_moment_render_all();
                             tinyMCE.get("acknowledgment-body").setContent(emailContent.html());
+                            editor.unblock();
+                            next3.prop('disabled', false);
                         }
                     });
 
@@ -227,6 +234,11 @@
                     second.hide();
                     third.show();
                 }
+                // Block tinymce until content is fully loaded by ajax
+                editor.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
             }
         });
 
@@ -248,6 +260,8 @@
                         fourth.find("input[name='tz-name']").val(jstz.determine().name());
                         fourth.find(".confirmation-header").text(data.header);
                         fourth.find(".method").val(method.val());
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 });
             } else {
@@ -265,11 +279,19 @@
                         fourth.find("input[name='tz-name']").val(jstz.determine().name());
                         fourth.find(".confirmation-header").text(data.header);
                         fourth.find(".method").val(method.val());
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 })
             }
             third.hide();
             fourth.show();
+            // Block confirmation until content is fully loaded by ajax
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            submit.prop('disabled', true);
         });
 
         prev2.click(function () {

--- a/app/templates/response/add_acknowledgment.js.html
+++ b/app/templates/response/add_acknowledgment.js.html
@@ -236,8 +236,8 @@
                 }
                 // Block tinymce until content is fully loaded by ajax
                 editor.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 next3.prop('disabled', true);
             }
@@ -289,8 +289,8 @@
             fourth.show();
             // Block confirmation until content is fully loaded by ajax
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             submit.prop('disabled', true);
         });

--- a/app/templates/response/add_acknowledgment.js.html
+++ b/app/templates/response/add_acknowledgment.js.html
@@ -33,8 +33,8 @@
 
         var edit_body_header = third.find('#edit-body-header');
 
-        var editor = $("#acknowledgment-editor");
-        var confirmation = $("#acknowledgment-confirmation");
+        var editor = $('#acknowledgment-editor');
+        var confirmation = $('#acknowledgment-confirmation');
 
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {

--- a/app/templates/response/add_acknowledgment.js.html
+++ b/app/templates/response/add_acknowledgment.js.html
@@ -239,6 +239,7 @@
                     message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
                     "<span class=\"sr-only\">Loading responses...</span></div></div>"
                 });
+                next3.prop('disabled', true);
             }
         });
 

--- a/app/templates/response/add_closing.html
+++ b/app/templates/response/add_closing.html
@@ -56,7 +56,7 @@
 
             <div class="third" hidden>
                 <h4 id="edit-body-header">Edit Email Body</h4>
-                <div id="editor" class="form-group">
+                <div id="closing-editor" class="form-group">
                     <div class="email-content-hidden" hidden></div>
                     <textarea title="closing-body" name="closing-body"
                               class="tinymce-area"></textarea>
@@ -67,7 +67,7 @@
 
             <div class="fourth" hidden>
                 <h4 class="confirmation-header"></h4>
-                <div id="confirmation" class="wrap-text summary"></div>
+                <div id="closing-confirmation" class="wrap-text summary"></div>
                 <input type="hidden" name="summary">
                 <button type="button" class="prev pull-left btn btn-default">Prev</button>
                 <button type="submit" class="submit pull-right btn btn-success">Submit</button>

--- a/app/templates/response/add_closing.html
+++ b/app/templates/response/add_closing.html
@@ -56,7 +56,7 @@
 
             <div class="third" hidden>
                 <h4 id="edit-body-header">Edit Email Body</h4>
-                <div class="form-group">
+                <div id="editor" class="form-group">
                     <div class="email-content-hidden" hidden></div>
                     <textarea title="closing-body" name="closing-body"
                               class="tinymce-area"></textarea>
@@ -67,7 +67,7 @@
 
             <div class="fourth" hidden>
                 <h4 class="confirmation-header"></h4>
-                <div class="wrap-text summary"></div>
+                <div id="confirmation" class="wrap-text summary"></div>
                 <input type="hidden" name="summary">
                 <button type="button" class="prev pull-left btn btn-default">Prev</button>
                 <button type="submit" class="submit pull-right btn btn-success">Submit</button>

--- a/app/templates/response/add_closing.js.html
+++ b/app/templates/response/add_closing.js.html
@@ -171,8 +171,6 @@
                         email_content: third.find("#closing-body").val()
                     },
                     success: function (data) {
-                        confirmation.unblock();
-                        submit.prop('disabled', false);
                         fourth.find(".summary").html(data.template);
                         fourth.find("input[name='summary']").val(data.template);
                         fourth.find(".confirmation-header").text(data.header);
@@ -180,6 +178,8 @@
                         if ($(".editable-span").text() === "") {
                             $(".editable-span").hide();
                         }
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 });
             } else {
@@ -193,12 +193,12 @@
                         letter_content: third.find("#closing-body").val()
                     },
                     success: function (data) {
-                        confirmation.unblock();
-                        submit.prop('disabled', false);
                         fourth.find(".summary").html(data.template);
                         fourth.find("input[name='summary']").val(data.template);
                         fourth.find(".confirmation-header").text(data.header);
                         fourth.find(".method").val(method.val());
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 });
             }

--- a/app/templates/response/add_closing.js.html
+++ b/app/templates/response/add_closing.js.html
@@ -27,8 +27,8 @@
 
         var edit_body_header = third.find("#edit-body-header");
 
-        var editor = $("#editor");
-        var confirmation = $("#confirmation");
+        var editor = $('#closing-editor');
+        var confirmation = $('#closing-confirmation');
 
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {

--- a/app/templates/response/add_closing.js.html
+++ b/app/templates/response/add_closing.js.html
@@ -151,8 +151,8 @@
                 }
                 // Block tinymce until content is fully loaded by ajax
                 editor.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 next3.prop('disabled', true);
             }
@@ -206,8 +206,8 @@
             fourth.show();
             // Block confirmation until content is fully loaded by ajax
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             submit.prop('disabled', true);
         });

--- a/app/templates/response/add_closing.js.html
+++ b/app/templates/response/add_closing.js.html
@@ -27,6 +27,9 @@
 
         var edit_body_header = third.find("#edit-body-header");
 
+        var editor = $("#editor");
+        var confirmation = $("#confirmation");
+
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {
             first.show();
@@ -112,6 +115,8 @@
                             var emailContent = third.find(".email-content-hidden");
                             emailContent.html(data.template);
                             tinyMCE.get("closing-body").setContent(emailContent.html());
+                            editor.unblock();
+                            next3.prop('disabled', false);
                         }
                     });
                     edit_body_header.html("Edit Email Body");
@@ -135,6 +140,8 @@
                             emailContent.html(data.template);
                             flask_moment_render_all();
                             tinyMCE.get("closing-body").setContent(emailContent.html());
+                            editor.unblock();
+                            next3.prop('disabled', false);
                         }
                     });
                     edit_body_header.html("Edit Letter Body");
@@ -142,6 +149,12 @@
                     second.hide();
                     third.show();
                 }
+                // Block tinymce until content is fully loaded by ajax
+                editor.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
+                next3.prop('disabled', true);
             }
         });
 
@@ -158,6 +171,8 @@
                         email_content: third.find("#closing-body").val()
                     },
                     success: function (data) {
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                         fourth.find(".summary").html(data.template);
                         fourth.find("input[name='summary']").val(data.template);
                         fourth.find(".confirmation-header").text(data.header);
@@ -178,6 +193,8 @@
                         letter_content: third.find("#closing-body").val()
                     },
                     success: function (data) {
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                         fourth.find(".summary").html(data.template);
                         fourth.find("input[name='summary']").val(data.template);
                         fourth.find(".confirmation-header").text(data.header);
@@ -187,6 +204,12 @@
             }
             third.hide();
             fourth.show();
+            // Block confirmation until content is fully loaded by ajax
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            submit.prop('disabled', true);
         });
 
         prev2.click(function() {

--- a/app/templates/response/add_denial.html
+++ b/app/templates/response/add_denial.html
@@ -55,7 +55,7 @@
             </div>
             <div class="third" hidden>
                 <h4 id="edit-body-header">Edit Email Body</h4>
-                <div class="form-group">
+                <div id="denial-editor" class="form-group">
                     <div class="email-content-hidden" hidden></div>
                     <textarea title="denial-body" name="denial-body"
                               class="tinymce-area"></textarea>
@@ -65,7 +65,7 @@
             </div>
             <div class="fourth" hidden>
                 <h4 class="confirmation-header"></h4>
-                <div class="wrap-text summary"></div>
+                <div id="denial-confirmation" class="wrap-text summary"></div>
                 <input type="hidden" name="summary">
                 <button type="button" class="prev pull-left btn btn-default">Prev</button>
                 <button type="submit" class="submit pull-right btn btn-success">Submit</button>

--- a/app/templates/response/add_denial.js.html
+++ b/app/templates/response/add_denial.js.html
@@ -27,6 +27,9 @@
 
         var edit_body_header = third.find('#edit-body-header');
 
+        var editor = $("#denial-editor");
+        var confirmation = $("#denial-confirmation");
+
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {
             first.show();
@@ -112,6 +115,8 @@
                             var emailContent = third.find(".email-content-hidden");
                             emailContent.html(data.template);
                             tinyMCE.get("denial-body").setContent(emailContent.html());
+                            editor.unblock();
+                            next3.prop('disabled', false);
                         }
                     });
                     edit_body_header.html("Edit Email Body");
@@ -135,6 +140,8 @@
                             emailContent.html(data.template);
                             flask_moment_render_all();
                             tinyMCE.get("denial-body").setContent(emailContent.html());
+                            editor.unblock();
+                            next3.prop('disabled', false);
                         }
                     });
                     edit_body_header.html("Edit Letter Body");
@@ -142,6 +149,12 @@
                     second.hide();
                     third.show();
                 }
+                // Block tinymce until content is fully loaded by ajax
+                editor.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
+                next3.prop('disabled', true);
             }
         });
 
@@ -165,6 +178,8 @@
                         if ($(".editable-span").text() === "") {
                             $(".editable-span").hide();
                         }
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 });
             } else {
@@ -182,11 +197,19 @@
                         fourth.find("input[name='summary']").val(data.template);
                         fourth.find(".confirmation-header").text(data.header);
                         fourth.find(".method").val(method.val());
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 });
             }
             third.hide();
             fourth.show();
+            // Block confirmation until content is fully loaded by ajax
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            submit.prop('disabled', true);
         });
 
         prev2.click(function () {

--- a/app/templates/response/add_denial.js.html
+++ b/app/templates/response/add_denial.js.html
@@ -151,8 +151,8 @@
                 }
                 // Block tinymce until content is fully loaded by ajax
                 editor.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 next3.prop('disabled', true);
             }
@@ -206,8 +206,8 @@
             fourth.show();
             // Block confirmation until content is fully loaded by ajax
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             submit.prop('disabled', true);
         });

--- a/app/templates/response/add_denial.js.html
+++ b/app/templates/response/add_denial.js.html
@@ -27,8 +27,8 @@
 
         var edit_body_header = third.find('#edit-body-header');
 
-        var editor = $("#denial-editor");
-        var confirmation = $("#denial-confirmation");
+        var editor = $('#denial-editor');
+        var confirmation = $('#denial-confirmation');
 
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {

--- a/app/templates/response/add_extension.html
+++ b/app/templates/response/add_extension.html
@@ -86,9 +86,10 @@
             <!-- third div of the add-extension form -->
             <div class="extension-divs hide-div form-group" id="extension-third" hidden>
                 <h4 id="edit-body-header">Edit Email Body</h4>
-                <div class="extension-body-hidden" hidden></div>
-                <textarea class="tinymce-area" name="extension-body"></textarea>
-                <br>
+                <div id="extension-editor" class="form-group">
+                    <div class="extension-body-hidden" hidden></div>
+                    <textarea class="tinymce-area" name="extension-body"></textarea>
+                </div>
                 <button type="button" class="prev-btn btn btn-default" id="extension-prev-3">Prev</button>
                 <button type="button" class="next-btn btn btn-primary" id="extension-next-3">Next</button>
             </div>
@@ -96,8 +97,8 @@
             <!-- last div of the add-extension form containing confirmation and submit -->
             <div class="extension-divs hide-div form-group" id="extension-fourth" hidden>
                 <h4 class="extension-confirmation-header"></h4>
-                <div class="wrap-text" id="summary"></div>
-                <input type="hidden" name="summary" id="summary-hidden">
+                <div class="wrap-text summary" id="extension-summary"></div>
+                <input type="hidden" name="summary" id="extension-summary-hidden">
                 <input type="hidden" name="tz-name" id="extension-tz-name">
                 <button type="button" class="prev-btn btn btn-default" id="extension-prev-4">Prev</button>
                 <button type="submit" class="submit-btn btn btn-success" id="extension-submit">Submit</button>

--- a/app/templates/response/add_extension.js.html
+++ b/app/templates/response/add_extension.js.html
@@ -167,8 +167,8 @@
             second.hide();
             third.show();
             editor.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             next3.prop('disabled', true);
         });
@@ -216,8 +216,8 @@
             third.hide();
             fourth.show();
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             submit.prop('disabled', true);
         });

--- a/app/templates/response/add_extension.js.html
+++ b/app/templates/response/add_extension.js.html
@@ -15,7 +15,7 @@
         var prev2 = second.find("#extension-prev-2");
         var prev3 = third.find("#extension-prev-3");
         var prev4 = fourth.find("#extension-prev-4");
-        var submit = fourth.find(".submit");
+        var submit = fourth.find(".submit-btn");
 
         var method = first.find("#extension-method");
         var email_div = second.find("#extension-email");
@@ -31,6 +31,9 @@
         for (var i = 0; i < required.length; i++) {
             required[i].attr("data-parsley-required", "");
         }
+
+        var editor = $('#extension-editor');
+        var confirmation = $('#extension-summary');
 
         // Reveal / Hide Letter Generation
         if (generate_letters_enabled === "True") {
@@ -108,12 +111,14 @@
                             emailContent.html(data.template);
                             flask_moment_render_all();
                             tinyMCE.get('extension-body').setContent(emailContent.html());
+                            editor.unblock();
+                            next3.prop('disabled', false);
                         }
                     });
                     edit_body_header.html("Edit Email Body");
                 }
             }
-            else{
+            else {
                 if ($("#custom-extension-letter").is(':visible')) {
                     $("#custom-extension-letter").parsley().validate();
                     if (!$('#custom-extension-letter').parsley().isValid()) {
@@ -153,12 +158,19 @@
                         letterContent.html(data.template);
                         flask_moment_render_all();
                         tinyMCE.get("extension-body").setContent(letterContent.html());
+                        editor.unblock();
+                        next3.prop('disabled', false);
                     }
                 });
                 edit_body_header.html("Edit Letter Body");
             }
             second.hide();
             third.show();
+            editor.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            next3.prop('disabled', true);
         });
 
         $(next3).click(function () {
@@ -173,10 +185,12 @@
                         email_content: $('#extension-body').val()
                     },
                     success: function (data) {
-                        $("#summary").html(data.template);
-                        $("#summary-hidden").val(data.template);
+                        $("#extension-summary").html(data.template);
+                        $("#extension-summary-hidden").val(data.template);
                         $("#extension-tz-name").val(jstz.determine().name());
                         $(".extension-confirmation-header").text(data.header);
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 });
             }
@@ -190,15 +204,22 @@
                         letter_content: $('#extension-body').val()
                     },
                     success: function (data) {
-                        $("#summary").html(data.template);
-                        $("#summary-hidden").val(data.template);
+                        $("#extension-summary").html(data.template);
+                        $("#extension-summary-hidden").val(data.template);
                         $("#extension-tz-name").val(jstz.determine().name());
                         $(".extension-confirmation-header").text(data.header);
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 })
             }
             third.hide();
             fourth.show();
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            submit.prop('disabled', true);
         });
 
         prev2.click(function () {

--- a/app/templates/response/add_file.html
+++ b/app/templates/response/add_file.html
@@ -76,15 +76,17 @@
                 <!-- second div of the add-file form containing email content -->
                 <div class="second" hidden>
                     <h4>Edit Email Body</h4>
-                    <div class="email-file-content-hidden" hidden></div>
-                    <textarea class="tinymce-area" name="email-file-content" title="email-content"></textarea>
+                    <div id="file-editor" class="form-group">
+                        <div class="email-file-content-hidden" hidden></div>
+                        <textarea class="tinymce-area" name="email-file-content" title="email-content"></textarea>
+                    </div>
                     <button type="button" class="prev prev-btn btn btn-default">Prev</button>
                     <button type="button" class="next next-btn btn btn-primary">Next</button>
                 </div>
                 <!-- last div of the add-file form containing confirmation and submit -->
                 <div class="third" hidden>
                     <h4 class="file-confirmation-header"></h4>
-                    <div class="wrap-text" id="email-file-summary"></div>
+                    <div class="wrap-text summary" id="email-file-summary"></div>
                     <!-- hidden input to send email summary to backend -->
                     <div class="email-hidden-div" hidden></div>
                     <input type="hidden" name="email-file-summary" id="email-file-summary-hidden">

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -127,8 +127,8 @@
                 first.hide();
                 second.show();
                 editor.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 next2.prop('disabled', true);
             }
@@ -161,8 +161,8 @@
             second.hide();
             third.show();
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             submit.prop('disabled', true);
         });

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -27,6 +27,9 @@
 
         var is_private;
 
+        var editor = $('#file-editor');
+        var confirmation = $('#email-file-summary');
+
         // Handles click events on the first next button
         next1.click(function (e) {
             var templateDownload = first.find(".template-download");
@@ -117,10 +120,17 @@
                         flask_moment_render_all();
                         tinyMCE.get('email-file-content').setContent(emailContent.html());
                         $(".file-confirmation-header").text(data.header);
+                        editor.unblock();
+                        next2.prop('disabled', false);
                     }
                 });
                 first.hide();
                 second.show();
+                editor.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
+                next2.prop('disabled', true);
             }
         });
 
@@ -144,10 +154,17 @@
                         return this.innerHTML == '&nbsp;';
                     }).remove();
                     hiddenEmailDiv.html(emailSummary.html());
+                    confirmation.unblock();
+                    submit.prop('disabled', false)
                 }
             });
             second.hide();
             third.show();
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            submit.prop('disabled', true);
         });
 
         // Handles click events on the first previous button

--- a/app/templates/response/add_instruction.html
+++ b/app/templates/response/add_instruction.html
@@ -41,15 +41,17 @@
             <!-- second div of the add-instruction form containing email content -->
             <div class="instruction-divs form-group" id="instruction-second">
                 <h4>Edit Email Body</h4>
-                <div class="email-instruction-content-hidden" hidden></div>
-                <textarea class="tinymce-area" name="email-instruction-content"></textarea>
+                <div id="instruction-editor" class="form-group">
+                    <div class="email-instruction-content-hidden" hidden></div>
+                    <textarea class="tinymce-area" name="email-instruction-content"></textarea>
+                </div>
                 <button type="button" class="prev-btn btn btn-default" id="instruction-prev-1">Prev</button>
                 <button type="button" class="next-btn btn btn-primary" id="instruction-next-2">Next</button>
             </div>
             <!-- last div of the add-instruction form containing confirmation and submit -->
             <div class="instruction-divs form-group" id="instruction-third">
                 <h4 class="instruction-confirmation-header"></h4>
-                <div class="wrap-text" id="email-instruction-summary"></div>
+                <div class="wrap-text summary" id="email-instruction-summary"></div>
                 <!-- hidden input to send email summary to backend -->
                 <input type="hidden" name="email-instruction-summary" id="email-instruction-summary-hidden">
                 <button type="button" class="prev-btn btn btn-default" id="instruction-prev-2">Prev</button>

--- a/app/templates/response/add_instruction.js.html
+++ b/app/templates/response/add_instruction.js.html
@@ -2,6 +2,9 @@
     "use strict";
 
     $(document).ready(function () {
+        var editor = $('#instruction-editor');
+        var confirmation = $('#email-instruction-summary');
+
         // Hides all other divs except for the first
         $(".instruction-control .instruction-divs").each(function (e) {
             if (e != 0)
@@ -36,10 +39,17 @@
                         flask_moment_render_all();
                         tinyMCE.get('email-instruction-content').setContent(emailContent.html());
                         $(".instruction-confirmation-header").text(data.header);
+                        editor.unblock();
+                        $('#instruction-next-2').prop('disabled', false);
                     }
                 });
                 document.getElementById("instruction-first").style.display = "none";
                 document.getElementById("instruction-second").style.display = "block";
+                editor.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
+                $('#instruction-next-2').prop('disabled', true);
             }
         });
 
@@ -57,10 +67,17 @@
                 success: function (data) {
                     $("#email-instruction-summary").html(data.template);
                     $("#email-instruction-summary-hidden").val(data.template);
+                    confirmation.unblock();
+                    $('#instruction-submit').prop('disabled', true);
                 }
             });
             document.getElementById("instruction-second").style.display = "none";
             document.getElementById("instruction-third").style.display = "block";
+            confirmation.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            $('#instruction-submit').prop('disabled', true);
         });
 
         // Handles click events on the first previous button

--- a/app/templates/response/add_instruction.js.html
+++ b/app/templates/response/add_instruction.js.html
@@ -46,8 +46,8 @@
                 document.getElementById("instruction-first").style.display = "none";
                 document.getElementById("instruction-second").style.display = "block";
                 editor.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 $('#instruction-next-2').prop('disabled', true);
             }
@@ -74,8 +74,8 @@
             document.getElementById("instruction-second").style.display = "none";
             document.getElementById("instruction-third").style.display = "block";
             confirmation.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             $('#instruction-submit').prop('disabled', true);
         });

--- a/app/templates/response/add_link.html
+++ b/app/templates/response/add_link.html
@@ -48,15 +48,17 @@
             <!-- second div of the add-link form containing email content -->
             <div class="link-divs form-group" id="link-second">
                 <h4>Edit Email Body</h4>
-                <div class="email-link-content-hidden" hidden></div>
-                <textarea class="tinymce-area" name="email-link-content"></textarea>
+                <div id="link-editor" class="form-group">
+                    <div class="email-link-content-hidden" hidden></div>
+                    <textarea class="tinymce-area" name="email-link-content"></textarea>
+                </div>
                 <button type="button" class="prev-btn btn btn-default" id="link-prev-1">Prev</button>
                 <button type="button" class="next-btn btn btn-primary" id="link-next-2">Next</button>
             </div>
             <!-- last div of the add-link form containing confirmation and submit -->
             <div class="link-divs form-group" id="link-third">
                 <h4 class="link-confirmation-header"></h4>
-                <div class="wrap-text" id="email-link-summary"></div>
+                <div class="wrap-text summary" id="email-link-summary"></div>
                 <!-- hidden input to send email summary to backend -->
                 <input type="hidden" name="email-link-summary" id="email-link-summary-hidden">
                 <button type="button" class="prev-btn btn btn-default" id="link-prev-2">Prev</button>

--- a/app/templates/response/add_link.js.html
+++ b/app/templates/response/add_link.js.html
@@ -2,6 +2,9 @@
     "use strict";
 
     $(document).ready(function () {
+        var editor = $('#link-editor');
+        var confirmation = $('#email-link-summary');
+
         // Hides all other divs except for the first
         $(".link-control .link-divs").each(function (e) {
             if (e != 0)
@@ -34,10 +37,17 @@
                         flask_moment_render_all();
                         tinyMCE.get('email-link-content').setContent(emailContent.html());
                         $(".link-confirmation-header").text(data.header);
+                        editor.unblock();
+                        $('#link-next-2').prop('disabled', false);
                     }
                 });
                 document.getElementById("link-first").style.display = "none";
                 document.getElementById("link-second").style.display = "block";
+                editor.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
+                $('#link-next-2').prop('disabled', true);
             }
         });
 
@@ -56,10 +66,17 @@
                     // Data should be html template page.
                     $("#email-link-summary").html(data.template);
                     $("#email-link-summary-hidden").val(data.template);
+                    confirmation.unblock();
+                    $('#link-submit').prop('disabled', false);
                 }
             });
             document.getElementById("link-second").style.display = "none";
             document.getElementById("link-third").style.display = "block";
+            confirmation.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            $('#link-submit').prop('disabled', true);
         });
 
         // Handles click events on the first previous button

--- a/app/templates/response/add_link.js.html
+++ b/app/templates/response/add_link.js.html
@@ -44,8 +44,8 @@
                 document.getElementById("link-first").style.display = "none";
                 document.getElementById("link-second").style.display = "block";
                 editor.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 $('#link-next-2').prop('disabled', true);
             }
@@ -73,8 +73,8 @@
             document.getElementById("link-second").style.display = "none";
             document.getElementById("link-third").style.display = "block";
             confirmation.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             $('#link-submit').prop('disabled', true);
         });

--- a/app/templates/response/add_note.html
+++ b/app/templates/response/add_note.html
@@ -55,17 +55,19 @@
 
                 <!-- second div of the add-note form containing email content -->
                 {% if current_user.is_agency %}
-                    <div class="note-divs form-group" id="note-second">
+                    <div class="note-divs" id="note-second">
                         <h4>Edit Email Body</h4>
-                        <div class="email-note-content-hidden" hidden></div>
-                        <textarea class="tinymce-area" name="email-note-content"></textarea>
+                        <div id="note-editor" class="form-group">
+                            <div class="email-note-content-hidden" hidden></div>
+                            <textarea class="tinymce-area" name="email-note-content"></textarea>
+                        </div>
                         <button type="button" class="prev-btn btn btn-default" id="note-prev-1">Prev</button>
                         <button type="button" class="next-btn btn btn-primary" id="note-next-2">Next</button>
                     </div>
                     <!-- last div of the add-note form containing confirmation and submit -->
                     <div class="note-divs form-group" id="note-third">
                         <h4 class="note-confirmation-header"></h4>
-                        <div class="wrap-text" id="email-note-summary"></div>
+                        <div class="wrap-text summary" id="email-note-summary"></div>
                         <!-- hidden input to send email summary to backend -->
                         <input type="hidden" name="email-note-summary" id="email-note-summary-hidden">
                         <button type="button" class="prev-btn btn btn-default" id="note-prev-2">Prev</button>

--- a/app/templates/response/add_note.js.html
+++ b/app/templates/response/add_note.js.html
@@ -2,8 +2,8 @@
     "use strict";
 
     $(document).ready(function () {
-        var editor = $("#note-editor");
-        var confirmation = $("#email-note-summary");
+        var editor = $('#note-editor');
+        var confirmation = $('#email-note-summary');
 
         // Hides all other divs except for the first
         $(".note-control .note-divs").each(function (e) {
@@ -40,7 +40,7 @@
                         tinyMCE.get('email-note-content').setContent(emailContent.html());
                         $(".note-confirmation-header").text(data.header);
                         editor.unblock();
-                        $("#note-next-2").prop('disabled', false);
+                        $('#note-next-2').prop('disabled', false);
                     }
                 });
                 document.getElementById("note-first").style.display = "none";
@@ -51,7 +51,7 @@
                 message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
                 "<span class=\"sr-only\">Loading responses...</span></div></div>"
             });
-            $("#note-next-2").prop('disabled', true);
+            $('#note-next-2').prop('disabled', true);
         });
 
         // Handles click events on the second next button
@@ -69,7 +69,7 @@
                     $("#email-note-summary").html(data.template);
                     $("#email-note-summary-hidden").val(data.template);
                     confirmation.unblock();
-                    $("#note-submit").prop('disabled', false);
+                    $('#note-submit').prop('disabled', false);
                 }
             });
             document.getElementById("note-second").style.display = "none";
@@ -79,7 +79,7 @@
                 message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
                 "<span class=\"sr-only\">Loading responses...</span></div></div>"
             });
-            $("#note-submit").prop('disabled', true);
+            $('#note-submit').prop('disabled', true);
         });
 
         // Handles click events on the first previous button

--- a/app/templates/response/add_note.js.html
+++ b/app/templates/response/add_note.js.html
@@ -2,6 +2,9 @@
     "use strict";
 
     $(document).ready(function () {
+        var editor = $("#note-editor");
+        var confirmation = $("#email-note-summary");
+
         // Hides all other divs except for the first
         $(".note-control .note-divs").each(function (e) {
             if (e != 0)
@@ -36,11 +39,19 @@
                         flask_moment_render_all();
                         tinyMCE.get('email-note-content').setContent(emailContent.html());
                         $(".note-confirmation-header").text(data.header);
+                        editor.unblock();
+                        $("#note-next-2").prop('disabled', false);
                     }
                 });
                 document.getElementById("note-first").style.display = "none";
                 document.getElementById("note-second").style.display = "block";
             }
+            // Block tinymce until content is fully loaded by ajax
+            editor.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            $("#note-next-2").prop('disabled', true);
         });
 
         // Handles click events on the second next button
@@ -57,10 +68,18 @@
                 success: function (data) {
                     $("#email-note-summary").html(data.template);
                     $("#email-note-summary-hidden").val(data.template);
+                    confirmation.unblock();
+                    $("#note-submit").prop('disabled', false);
                 }
             });
             document.getElementById("note-second").style.display = "none";
             document.getElementById("note-third").style.display = "block";
+            // Block confirmation until content is fully loaded by ajax
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            $("#note-submit").prop('disabled', true);
         });
 
         // Handles click events on the first previous button

--- a/app/templates/response/add_note.js.html
+++ b/app/templates/response/add_note.js.html
@@ -48,8 +48,8 @@
             }
             // Block tinymce until content is fully loaded by ajax
             editor.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             $('#note-next-2').prop('disabled', true);
         });
@@ -76,8 +76,8 @@
             document.getElementById("note-third").style.display = "block";
             // Block confirmation until content is fully loaded by ajax
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             $('#note-submit').prop('disabled', true);
         });

--- a/app/templates/response/add_reopening.html
+++ b/app/templates/response/add_reopening.html
@@ -47,7 +47,7 @@
             </div>
             <div class="second" hidden>
                 <h4 id="edit-body-header">Edit Email Body</h4>
-                <div class="form-group">
+                <div id="reopening-editor" class="form-group">
                     <div class="reopen-content-hidden" hidden></div>
                     <textarea title="reopening-body" name="reopening-body"
                               class="tinymce-area"></textarea>
@@ -57,7 +57,7 @@
             </div>
             <div class="third" hidden>
                 <h4 id="header">The following will be emailed to the requester:</h4>
-                <div class="wrap-text summary"></div>
+                <div id="reopening-confirmation" class="wrap-text summary"></div>
                 <input type="hidden" name="method">
                 <input type="hidden" name="letter-template-id">
                 <input type="hidden" name="summary">

--- a/app/templates/response/add_reopening.js.html
+++ b/app/templates/response/add_reopening.js.html
@@ -23,6 +23,9 @@
         var reason = first.find("#reopening-reason-id");
         var date = first.find("#reopening-date");
 
+        var editor = $('#reopening-editor');
+        var confirmation = $('#reopening-confirmation');
+
         // Parsley
         method.attr("data-parsley-required", "");
         date.attr("data-parsley-required", "");
@@ -123,7 +126,8 @@
                             emailContent.html(data.template);
                             flask_moment_render_all();
                             tinyMCE.get("reopening-body").setContent(emailContent.html());
-
+                            editor.unblock();
+                            next2.prop('disabled', false);
                         }
                     });
                     edit_body_header.html("Edit Email Body");
@@ -145,12 +149,19 @@
                             letterContent.html(data.template);
                             flask_moment_render_all();
                             tinyMCE.get("reopening-body").setContent(letterContent.html());
+                            editor.unblock();
+                            next2.prop('disabled', false);
                         }
                     });
                     edit_body_header.html("Edit Letter Body");
                 }
                 first.hide();
                 second.show();
+                editor.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
+                next2.prop('disabled', true);
             }
         });
 
@@ -173,6 +184,8 @@
                         third.find(".confirmation-header").text(data.header);
                         third.find(".method").val(method.val());
                         third.find("#header").html(data.header)
+                        confirmation.unblock();
+                        submit.prop('disabled', false)
                     }
                 })
             } else {
@@ -192,12 +205,18 @@
                         third.find(".confirmation-header").text(data.header);
                         third.find(".method").val(method.val());
                         third.find("#header").html(data.header)
+                        confirmation.unblock();
+                        submit.prop('disabled', false)
                     }
                 });
             }
-
             second.hide();
             third.show();
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            submit.prop('disabled', true);
         });
 
 

--- a/app/templates/response/add_reopening.js.html
+++ b/app/templates/response/add_reopening.js.html
@@ -158,8 +158,8 @@
                 first.hide();
                 second.show();
                 editor.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 next2.prop('disabled', true);
             }
@@ -213,8 +213,8 @@
             second.hide();
             third.show();
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             submit.prop('disabled', true);
         });

--- a/app/templates/response/add_user_request.html
+++ b/app/templates/response/add_user_request.html
@@ -28,12 +28,13 @@
                     </div>
                     {{ add_user_request_form.permission.label }}<br>
                     {{ add_user_request_form.permission(id="permission", class="form-control", size=permissions_length) }}
+                    <br>
                     <button type="button" class="next pull-right btn btn-primary">Next</button>
                 </div>
             </div>
             <div class="second" hidden>
                 <h4>The following will be emailed to&nbsp;<span id="user_name"></span>:</h4>
-                <div class="wrap-text email-summary"></div>
+                <div id="add-user-confirmation" class="wrap-text email-summary summary"></div>
                 <input type="hidden" name="email-summary">
                 <button type="button" class="prev pull-left btn btn-default">Prev</button>
                 <button type="submit" class="submit pull-right btn btn-success">Submit</button>

--- a/app/templates/response/add_user_request.js.html
+++ b/app/templates/response/add_user_request.js.html
@@ -15,6 +15,8 @@
         var user = first.find("#user");
         var permission = first.find("#permission");
 
+        var confirmation = $('#add-user-confirmation');
+
         permission.find("option").mousedown(function (e) {
             e.preventDefault();
             permission.focus();
@@ -49,11 +51,18 @@
                 },
                 success: function (data) {
                     $(".email-summary").html(data.template);
-                    first.hide();
-                    second.show();
                     $("#user_name").text(data.name);
+                    confirmation.unblock();
+                    submit.prop('disabled', false);
                 }
             });
+            first.hide();
+            second.show();
+            confirmation.block({
+                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+            });
+            submit.prop('disabled', true);
         });
 
         prev.click(function () {

--- a/app/templates/response/add_user_request.js.html
+++ b/app/templates/response/add_user_request.js.html
@@ -59,8 +59,8 @@
             first.hide();
             second.show();
             confirmation.block({
-                message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                '<span class=\"sr-only\">Loading content...</span></div></div>'
             });
             submit.prop('disabled', true);
         });

--- a/app/templates/response/edit_user_request.html
+++ b/app/templates/response/edit_user_request.html
@@ -29,12 +29,13 @@
                     {{ edit_user_request_form.permission.label }}<br>
                     {{ edit_user_request_form.permission(id="permission", class="form-control", size=permissions_length) }}
                     <h5 id="no-permissions-changed-error" style="display: none">No changes in permissions detected</h5>
+                    <br>
                     <button type="button" class="next pull-right btn btn-primary">Next</button>
                 </div>
             </div>
             <div class="second" hidden>
                 <h4>The following will be emailed to&nbsp;<span id="user_name"></span>:</h4>
-                <div class="wrap-text email-summary"></div>
+                <div id="edit-user-confirmation" class="wrap-text email-summary summary"></div>
                 <input type="hidden" name="email-summary">
                 <input type="hidden" name="tz-name">
                 <button type="button" class="prev pull-left btn btn-default">Prev</button>

--- a/app/templates/response/edit_user_request.js.html
+++ b/app/templates/response/edit_user_request.js.html
@@ -20,6 +20,8 @@
         var point_of_contact = $("#edit_point_of_contact");
         var point_of_contact_state;
 
+        var confirmation = $('#edit-user-confirmation');
+
         function setPermissions(perms) {
             permission.children().each(function () {
                 if (perms.indexOf(Number($(this).val())) !== -1) {
@@ -112,11 +114,18 @@
                     },
                     success: function (data) {
                         $(".email-summary").html(data.template);
-                        first.hide();
-                        second.show();
                         $("#user_name").text(data.name);
+                        confirmation.unblock();
+                        submit.prop('disabled', false);
                     }
                 });
+                first.hide();
+                second.show();
+                confirmation.block({
+                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
+                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                });
+                submit.prop('disabled', true);
             }
             else {
                 $('#no-permissions-changed-error').css({"color": "red", "display": ""});

--- a/app/templates/response/edit_user_request.js.html
+++ b/app/templates/response/edit_user_request.js.html
@@ -122,8 +122,8 @@
                 first.hide();
                 second.show();
                 confirmation.block({
-                    message: "<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">" +
-                    "<span class=\"sr-only\">Loading responses...</span></div></div>"
+                    message: '<div class=\"col-sm-12 loading-container\"><div class=\"loading-spinner\">' +
+                    '<span class=\"sr-only\">Loading content...</span></div></div>'
                 });
                 submit.prop('disabled', true);
             }


### PR DESCRIPTION
This PR fixes a bug where emails were not being created and sent out if ajax calls didn't finish causing the backend to not receive the email content. I fixed this on both the backend and frontend.

For the backend it should flash a message if it doesn't receive one of the required fields such as the email summary. Previously some of the responses had a check that looked like:

`if response.get(field) is None:`

This causes python to throw an error because if the summary was missing it would be empty string and str type can't be compared to None type. So it would skip the message flash to stop the process and instead proceed to creating the response but not the associated Email object with it. So I fixed this by updating the check for the required to fields to make sure it's not empty string, some of the other responses already used this check, we just weren't consistent.

On the frontend, I added spinners for tinymce and the email confirmation step to wait until it receives the content from the ajax call. I also disabled the next and submit buttons until the ajax finishes. 