### PR TITLE
Bugfix/OP-1621: Editing Requester Information

### DIFF
--- a/app/user/views.py
+++ b/app/user/views.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime
 
 from flask import jsonify, request
@@ -168,8 +169,8 @@ def patch(user_id):
     new_status = {}
 
     # User Attributes for Events
-    old_user_attrs = {'_mailing_address': {}}
-    new_user_attrs = {'_mailing_address': {}}
+    old_user_attrs = defaultdict(dict)
+    new_user_attrs = defaultdict(dict)
 
     for key, value in status_field_val.items():
         if value is not None:
@@ -203,7 +204,7 @@ def patch(user_id):
                 new_user_attrs[key] = new_val
 
     # Update the Users object if new_user_attrs is not None (empty dict)
-    if new_user_attrs and new_user_attrs.get('_mailing_address') and old_user_attrs:
+    if new_user_attrs and old_user_attrs:
         update_object(
             new_user_attrs,
             Users,


### PR DESCRIPTION
This PR fixes the edit requester information functionality. 

The bug was caused by the check for `new_user_attrs.get('_mailing_address')`. If anything but the mailing address was changed, the if statement would still be `False` because we initialize the key `'_mailing_address'` as an empty dictionary. The fix is to initialize both `old_user_attrs` and `new_user_attrs` as a`defaultdict(dict)` so that the nested key (`'_mailing_address'`) is created in the for loop if address fields are changed.