### PR TITLE
BugFix/OP-1621: Resolve error with state and zip code.

### DIFF
--- a/app/constants/user_attrs.py
+++ b/app/constants/user_attrs.py
@@ -84,7 +84,7 @@ class UserAddressDict(dict):
         self['address_two'] = kwargs.get('address_two')
         self['city'] = kwargs.get('city')
         self['state'] = kwargs.get('state')
-        self['zip'] = kwargs.get('zipcode')
+        self['zip'] = kwargs.get('zip')
 
     def __setitem__(self, key, value):
         if key not in UserAddressDict._keys:

--- a/app/static/js/request/edit_requester_info.js
+++ b/app/static/js/request/edit_requester_info.js
@@ -17,6 +17,7 @@ $(function () {
     var zipCode = $("#inputZip");
     var email = $("#inputEmail");
     var state = $("#inputState");
+    var selected_state_value = $("#inputState option:selected").val();
     var city = $("#inputCity");
     var addressOne = $("#inputAddressOne");
 
@@ -125,6 +126,7 @@ $(function () {
         for (i = 0; i < all.length; i++) {
             all[i].val(all[i].attr("value"));
         }
+        state.val(selected_state_value);
         for (i = 0; i < required.length; i++) {
             $("#user-info").parsley().reset();
         }

--- a/app/user/views.py
+++ b/app/user/views.py
@@ -151,6 +151,7 @@ def patch(user_id):
         address_two=request.form.get('address_two'),
         zip=request.form.get('zipcode'),
         city=request.form.get('city'),
+        state=request.form.get('state')
     )
     status_field_val = user_attrs.UserStatusDict(
         is_agency_admin=request.form.get('is_agency_admin'),


### PR DESCRIPTION
Resolves the issue where the state was being set to None if the modal
dialog was closed before hitting submit. This was due to the way select
fields are handled. In order to get the value of a select field you need
to select the option value within the select field and get its value.
Without this, an empty string was being returned.
To resolve this, the state value, if present, is stored in JS on page
load and then used on the reset modal callback to restore the state.

To resolve the issue with the missing state and zipcode on the backend,
the UserAddressDict was modified to use the right keys when storing
the values of zip and state (in the case of state, it just wasn't
present in the initialization function.)