### PR TITLE
Feature/OP-1652: Add Request Type to Emails

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -390,7 +390,7 @@ class Users(UserMixin, db.Model):
 
     @property
     def is_active(self):
-        return self.email_validated and self.terms_of_use_accepted
+        return self.email_validated
 
     @property
     def is_public(self):

--- a/app/templates/email_templates/email_confirmation.html
+++ b/app/templates/email_templates/email_confirmation.html
@@ -12,6 +12,9 @@
                             </p>
                             <!-- Contact and Request Information -->
                             <p>
+                                {% if current_request.custom_metadata %}
+                                    Request Type: {{ current_request.description }}
+                                {% endif %}
                                 {% if file_link %}
                                     Attached File: {{ file_link['title'] }}:
                                     <a href="{{ file_link['link'] }}">{{ file_link['filename'] }}</a>

--- a/app/templates/email_templates/email_request_status_changed.html
+++ b/app/templates/email_templates/email_request_status_changed.html
@@ -7,6 +7,9 @@
             <li>
                 <a href="{{ request.url }}">{{ request.id }}</a>
                 <ul>
+                    {% if request.custom_metadata %}
+                        <li>Request Type: {{ request.description }}</li>
+                    {% endif %}
                     <li>Requester Last Name: {{ request.requester.last_name }}</li>
                     <li>Request Opened: {{ request.date_submitted.strftime('%m/%d/%y') }}</li>
                 </ul>
@@ -23,6 +26,9 @@
                 <li>
                     <a href="{{ request.url }}">{{ request.id }}</a>
                     <ul>
+                        {% if request.custom_metadata %}
+                            <li>Request Type: {{ request.description }}</li>
+                        {% endif %}
                         <li>Requester Last Name: {{ request.requester.last_name }}</li>
                         <li>Request Opened: {{ request.date_submitted.strftime('%m/%d/%y') }}</li>
                     </ul>
@@ -46,6 +52,9 @@
                     {% endif %}
                 </strong>
                 <ul>
+                    {% if request.custom_metadata %}
+                        <li>Request Type: {{ request.description }}</li>
+                    {% endif %}
                     <li>Requester Last Name: {{ request.requester.last_name }}</li>
                     <li>Request Opened: {{ request.date_submitted.strftime('%m/%d/%y') }}</li>
                 </ul>
@@ -69,6 +78,9 @@
                         {% endif %}
                     </strong>
                     <ul>
+                        {% if request.custom_metadata %}
+                            <li>Request Type: {{ request.description }}</li>
+                        {% endif %}
                         <li>Requester Last Name: {{ request.requester.last_name }}</li>
                         <li>Request Opened: {{ request.date_submitted.strftime('%m/%d/%y') }}</li>
                     </ul>


### PR DESCRIPTION
This PR adds "Request Type" to the confirmation email and the nightly request status report email if the agency is using custom request forms. We are using `description` as the value because the name of the custom form is appended to the request description.

Also included is the removal of `terms_of_use_accepted` from the `is_active` check. This is our temporary workaround until we fully implement the following ticket: https://nycrecords.atlassian.net/browse/OP-1653