### PR TITLE
Feature/OP-1661: Updated date conversion to account for EST to UTC difference

### DIFF
--- a/app/report/views.py
+++ b/app/report/views.py
@@ -3,7 +3,7 @@
 
    :synopsis: Handles the report URL endpoints for the OpenRecords application
 """
-from datetime import datetime
+from datetime import datetime, timedelta
 from calendar import monthrange
 from io import BytesIO
 
@@ -221,7 +221,7 @@ def open_data_report():
         date_from = local_to_utc(datetime.strptime(request.form['date_from'], '%m/%d/%Y'),
                                  current_app.config['APP_TIMEZONE'])
         date_to = local_to_utc(datetime.strptime(request.form['date_to'], '%m/%d/%Y'),
-                               current_app.config['APP_TIMEZONE'])
+                               current_app.config['APP_TIMEZONE']) + timedelta(days=1)
 
         open_data_report_spreadsheet = generate_open_data_report(current_user.default_agency_ein,
                                                                  date_from,


### PR DESCRIPTION
Added one day to `date_to` to account for all requests that come in during that day until midnight.

ex) 

date_to = 5/25/20 converts to 2020-06-25 04:00:00 UTC which is 2020-06-25 00:00:00 EST which is the start of the day (we will miss all requests submitted during the day)
 
date_to + timedelta(days=1) gives you 5/26/20 which converts to 2020-06-26 04:00:00 UTC which is 2020-06-26 00:00:00 EST which is the beginning of 5/26 (effectively end of day 5/25)