### PR TITLE
Extend Requests and Update Request Statuses

### DIFF
--- a/app/jobs.py
+++ b/app/jobs.py
@@ -21,17 +21,17 @@ STATUSES_EMAIL_SUBJECT = "Nightly Request Status Report"
 STATUSES_EMAIL_TEMPLATE = "email_templates/email_request_status_changed"
 
 
-@celery.task(autoretry_for=(OperationalError, SQLAlchemyError,), retry_kwargs={'max_retries': 5}, retry_backoff=True)
-def update_request_statuses():
-    try:
-        _update_request_statuses()
-    except Exception:
-        db.session.rollback()
-        send_email(
-            subject="Update Request Statuses Failure",
-            to=[OPENRECORDS_DL_EMAIL],
-            email_content=traceback.format_exc().replace("\n", "<br/>").replace(" ", "&nbsp;")
-        )
+# @celery.task(autoretry_for=(OperationalError, SQLAlchemyError,), retry_kwargs={'max_retries': 5}, retry_backoff=True)
+# def update_request_statuses():
+#     try:
+#         _update_request_statuses()
+#     except Exception:
+#         db.session.rollback()
+#         send_email(
+#             subject="Update Request Statuses Failure",
+#             to=[OPENRECORDS_DL_EMAIL],
+#             email_content=traceback.format_exc().replace("\n", "<br/>").replace(" ", "&nbsp;")
+#         )
 
 
 def _update_request_statuses():

--- a/app/templates/email_templates/email_response_extension_cli.html
+++ b/app/templates/email_templates/email_response_extension_cli.html
@@ -1,0 +1,19 @@
+{% if default_content %}
+    <p>
+        The {{ agency_name }} has <strong>extended</strong> the time to respond to your FOIL request
+        <a href="{{ page }}" target="_blank">{{ request_id }}</a> for the following reasons:
+    </p>
+    <p>
+        <span class="mceNonEditable">
+        You can expect a response on or about {{ new_due_date }}.<br /><br />
+        Additional Information: <br />
+        </span>
+    </p>
+    <div class="mceNonEditable">
+        {{ reason | safe }}
+        <br /><br />
+        Please visit <a href="{{ page }}">{{ request_id }}</a> to view additional information and take any necessary action.
+    </div>
+{% else %}
+    {{ content | safe }}
+{% endif %}

--- a/openrecords.py
+++ b/openrecords.py
@@ -237,8 +237,7 @@ def es_recreate():
 @click.option("--user_guid", prompt="User GUID")
 @click.option("--extension_date", prompt="Extension Date (e.g. 01/01/2022)")
 @click.option("--extension_reason", prompt="Extension Reason")
-@click.option("--url", prompt="URL (eg. https://10.0.0.2/")
-def extend_requests(agency_ein: str, agency_name: str, user_guid: str, extension_date: str, extension_reason: str, url:str):
+def extend_requests(agency_ein: str, agency_name: str, user_guid: str, extension_date: str, extension_reason: str):
     # Create request context
     ctx = app.test_request_context()
     ctx.push()
@@ -262,7 +261,7 @@ def extend_requests(agency_ein: str, agency_name: str, user_guid: str, extension
                                    agency_name=agency_name,
                                    new_due_date=new_due_date.strftime("%A, %B %-d, %Y"),
                                    reason=extension_reason,
-                                   page=urljoin(url, url_for('request.view', request_id=request.id)))
+                                   page=urljoin(app.config['BASE_URL'], url_for('request.view', request_id=request.id)))
             add_extension(request.id,
                           '-1',
                           extension_reason,


### PR DESCRIPTION
This PR adds a CLI command called `extend_requests` to extend all "Overdue" requests for a particular agency.

Example usage:
`flask extend-requests --agency_ein '0056' --agency_name 'New York City Police Department (NYPD)' --user_guid 'add1c7f91d7b49c4ab4cbf70683301ab' --extension_date '03/15/2022' --extension_reason 'test reason'`

Also created a CLI command called `update_request_statuses` to perform the update request statuses job as a cron job.

Example crontab:
`0 0 * * * source /opt/rh/rh-python35/enable && cd /vagrant && /home/vagrant/.virtualenvs/openrecords/bin/flask update-request-statuses >> /tmp/cron_output`