### PR TITLE
Fix Custom Forms Loading Part 2

### DIFF
--- a/app/request/views.py
+++ b/app/request/views.py
@@ -141,15 +141,14 @@ def new():
                 )
 
         custom_metadata = json.loads(
-            flask_request.form.get("custom-request-forms-data", {})
+            flask_request.form.get("custom-request-forms-data", '{}')
         )
         # validate that custom_metadata JSON has data if custom request forms are enabled for the agency
         agency_ein = (form.request_agency.data
                       if form.request_agency.data != "None"
                       else current_user.default_agency_ein)
         agency_object = Agencies.query.filter_by(ein=agency_ein).first()
-        if "enabled" in agency_object.agency_features["custom_request_forms"] and \
-                agency_object.agency_features["custom_request_forms"]["enabled"] and not custom_metadata:
+        if agency_object.agency_features["custom_request_forms"]["enabled"] and not custom_metadata:
             flash('An unexpected error occurred. Please reload the page and try submitting your request again.',
                   category='danger')
             return redirect(url_for("request.new"))

--- a/app/request/views.py
+++ b/app/request/views.py
@@ -143,6 +143,16 @@ def new():
         custom_metadata = json.loads(
             flask_request.form.get("custom-request-forms-data", {})
         )
+        # validate that custom_metadata JSON has data if custom request forms are enabled for the agency
+        agency_ein = (form.request_agency.data
+                      if form.request_agency.data != "None"
+                      else current_user.default_agency_ein)
+        agency_object = Agencies.query.filter_by(ein=agency_ein).first()
+        if "enabled" in agency_object.agency_features["custom_request_forms"] and \
+                agency_object.agency_features["custom_request_forms"]["enabled"] and not custom_metadata:
+            flash('An unexpected error occurred. Please reload the page and try submitting your request again.',
+                  category='danger')
+            return redirect(url_for("request.new"))
         # validate that form_name exists in custom_metadata JSON
         for key,value in custom_metadata.items():
             form_name = value.get('form_name', None)

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -12,6 +12,16 @@
 "use strict";
 
 $(document).ready(function () {
+    // Reload the page if it was loaded from a cached version (back browser button).
+    // Used to clear out form data and ensure custom request forms are properly loaded.
+    (function () {
+        window.onpageshow = function (event) {
+            if (event.persisted) {
+                window.location.reload();
+            }
+        };
+    })();
+
     // Determine if the agencyRequestInstructions and custom request forms need to be shown on page load.
     getRequestAgencyInstructions();
     // Check for custom request forms on page load (browser back button behavior).

--- a/app/static/js/request/new-request-user.js
+++ b/app/static/js/request/new-request-user.js
@@ -12,6 +12,16 @@
 "use strict";
 
 $(document).ready(function () {
+    // Reload the page if it was loaded from a cached version (back browser button).
+    // Used to clear out form data and ensure custom request forms are properly loaded.
+    (function () {
+        window.onpageshow = function (event) {
+            if (event.persisted) {
+                window.location.reload();
+            }
+        };
+    })();
+
     // Determine if the agencyRequestInstructions need to be shown on page load.
     getRequestAgencyInstructions();
     // Check for custom request forms on page load (browser back button behavior).

--- a/app/templates/request/new_request_anon.js.html
+++ b/app/templates/request/new_request_anon.js.html
@@ -10,6 +10,16 @@
     "use strict";
 
     $(document).ready(function () {
+        // Reload the page if it was loaded from a cached version (back browser button).
+        // Used to clear out form data and ensure custom request forms are properly loaded.
+        (function () {
+            window.onpageshow = function (event) {
+                if (event.persisted) {
+                    window.location.reload();
+                }
+            };
+        })();
+
         {% if kiosk_mode %}
             $("#request-category").prop('disabled', true);
             $("#request-agency").prop('disabled', true);
@@ -24,6 +34,7 @@
         {% if title %}
             $("#request-title").val("{{ title }}");
         {% endif %}
+
         // Determine if the agencyRequestInstructions need to be shown on page load.
         getRequestAgencyInstructions();
         // Check for custom request forms on page load (browser back button behavior).


### PR DESCRIPTION
This PR adds the following to improve custom request form functionality:
- Backend validation to check that custom request form metadata exists on submission.
- Javascript to reload the page if loaded from a cached version. This fixes the issue with the browser back button not keeping the keeping the custom form and reverting back to the Request Description field.

Referenced: https://gomakethings.com/fixing-safaris-back-button-browser-cache-issue-with-vanilla-js/ 