### PR TITLE
Updated Logic for Contact Emails

### DIFF
--- a/app/lib/email_utils.py
+++ b/app/lib/email_utils.py
@@ -35,8 +35,8 @@ def send_async_email(msg):
         current_app.logger.exception("Failed to Send Email {} : {}".format(msg, e))
 
 
-def send_contact_email(subject, recipients, body, reply_to):
-    msg = Message(subject, recipients, body, sender=current_app.config['MAIL_SENDER'], reply_to=reply_to)
+def send_contact_email(subject, recipients, body, sender, reply_to):
+    msg = Message(subject, recipients, body, sender=sender, reply_to=reply_to)
     send_async_email.delay(msg)
 
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -85,9 +85,9 @@ def technical_support():
                 )
             )
             if current_user.is_agency:
-                send_contact_email(subject, [current_app.config['OPENRECORDS_AGENCY_SUPPORT_DL']], body, email)
+                send_contact_email(subject, [current_app.config['OPENRECORDS_AGENCY_SUPPORT_DL']], body, email, None)
             else:
-                send_contact_email(subject, [OPENRECORDS_DL_EMAIL], body, email)
+                send_contact_email(subject, [OPENRECORDS_DL_EMAIL], body, current_app.config['MAIL_SENDER'], email)
             flash('Your message has been sent. We will get back to you.', category='success')
         else:
             flash('Cannot send email.', category='danger')

--- a/app/request/utils.py
+++ b/app/request/utils.py
@@ -603,5 +603,6 @@ def create_contact_record(request, first_name, last_name, email, subject, messag
         subject,
         agency_emails,
         body,
+        current_app.config['MAIL_SENDER'],
         email
     )


### PR DESCRIPTION
This PR updates the logic for contact emails so that sender and reply-to are set separately.

For Contact the Agency emails:
- Sender will be donotreply@records.nyc.gov
- Reply-to will be the submitting user's email

For anonymous technical support emails:
- Sender will be donotreply@records.nyc.gov
- Reply-to will be the submitting user's email

For agency technical support emails:
- Sender will be the agency user's email (so that reporter is properly set in the service desk)
- Reply-to will not be set 