### PR TITLE
Added CLI command to close requests

### DIFF
--- a/app/agency/utils.py
+++ b/app/agency/utils.py
@@ -65,12 +65,16 @@ def update_agency_active_status(agency_ein, is_active):
             )
             # remove requests from index
             for request in agency.requests:
-                request.es_delete()
+                try:
+                    request.es_delete()
+                except Exception as e:
+                    # exception for document not found
+                    print(e)
             # deactivate agency users
             for user in agency.active_users:
                 update_object(
-                    {"is_agency_active": "False",
-                     "is_agency_admin": "False"},
+                    {"is_agency_active": False,
+                     "is_agency_admin": False},
                     AgencyUsers,
                     (user.guid, agency_ein)
                 )

--- a/app/models.py
+++ b/app/models.py
@@ -1303,11 +1303,11 @@ class Responses(db.Model):
 
     # TODO: overwrite filter to automatically check if deleted=False
 
-    def __init__(self, request_id, privacy, date_modified=None, is_editable=False, is_dataset=False, dataset_description=None):
+    def __init__(self, request_id, privacy, date_modified=None, release_date=None, is_editable=False, is_dataset=False, dataset_description=None):
         self.request_id = request_id
         self.privacy = privacy
         self.date_modified = date_modified or datetime.utcnow()
-        self.release_date = (
+        self.release_date = release_date or (
             calendar.addbusdays(datetime.utcnow(), RELEASE_PUBLIC_DAYS)
             if privacy == response_privacy.RELEASE_AND_PUBLIC
             else None
@@ -1955,10 +1955,11 @@ class Determinations(Responses):
         reason,
         date=None,
         date_modified=None,
+        release_date=None,
         is_editable=False,
     ):
         super(Determinations, self).__init__(
-            request_id, privacy, date_modified, is_editable
+            request_id, privacy, date_modified, release_date, is_editable
         )
         self.dtype = dtype
 

--- a/data/agencies.json
+++ b/data/agencies.json
@@ -1212,7 +1212,7 @@
           "text": "<p>For information or assistance with services for older adults, including caregiver services, please call <strong>Aging Connect</strong>, NYC Department for the Aging’s information and referral contact center, at <strong>212-244-6469</strong>. You may also submit an inquiry online at: <a target='_blank' rel='noopener noreferrer' href='https://www.nyc.gov/site/dfta/about/contact-aging-connect.page' >https://www.nyc.gov/site/dfta/about/contact-aging-connect.page</a>.</p><br><p>Requests for employment records of current and/or former NYC Department for the Aging employees should be directed to the NYC Department for the Aging’s Office of Human Resources at: <a href='mailto:benefitsleave@aging.nyc.gov'>benefitsleave@aging.nyc.gov</a>.</p><br><p>Requests related to police reports, arrest records, criminal complaints, or other criminal records should be directed to the <strong>New York City Police Department (NYPD)</strong> by selecting “NYPD” in the Agency drop-down menu above.</p>"
         }
       },
-      "acronym": "DFTA"
+      "acronym": "NYC Aging"
     },
     {
       "ein": "0003",


### PR DESCRIPTION
This PR creates a CLI command to automate the closing of requests for an agency.

Created `add_closing_cli` that differs from `add_closing_cli` in the following ways:
- Removes check to determine if a request has been acknowledged
- Removes email and letter functionality when closing request, no emails sent to users
- Sets response release date to release immediately once the request is closed
- Takes in a `reason_text` parameter instead of a `reason_id`

Other changes:
- Add try/except block for `es_delete` when deactivating an agency
- Updated response constructor to take in release_date parameter

To run CLI command:
```
(openrecords)[vagrant@localhost vagrant]$ flask close-requests
Agency EIN (e.g. 0056): 0850
User GUID: <USER_GUID>
Reason text: This request was handled by the agency externally from the OpenRecords portal.
```