### PR TITLE
Fix Super Function for Responses

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1589,9 +1589,9 @@ class Notes(Responses):
     content = db.Column(db.String)
 
     def __init__(
-        self, request_id, privacy, content, date_modified=None, is_editable=False
+        self, request_id, privacy, content, date_modified=None, release_date=None, is_editable=False
     ):
-        super(Notes, self).__init__(request_id, privacy, date_modified, is_editable)
+        super(Notes, self).__init__(request_id, privacy, date_modified, release_date, is_editable)
         self.content = content
 
     @property
@@ -1630,6 +1630,7 @@ class Files(Responses):
         size,
         hash_,
         date_modified=None,
+        release_date=None,
         is_editable=False,
         is_dataset=False,
         dataset_description=None
@@ -1646,7 +1647,7 @@ class Files(Responses):
             sentry.captureException()
             raise DuplicateFileException(file_name=name, request_id=request_id)
 
-        super(Files, self).__init__(request_id, privacy, date_modified, is_editable, is_dataset, dataset_description)
+        super(Files, self).__init__(request_id, privacy, date_modified, release_date, is_editable, is_dataset, dataset_description)
         self.name = name
         self.mime_type = mime_type
         self.title = title
@@ -1674,9 +1675,9 @@ class Links(Responses):
     url = db.Column(db.String)
 
     def __init__(
-        self, request_id, privacy, title, url, date_modified=None, is_editable=False, is_dataset=False, dataset_description=None
+        self, request_id, privacy, title, url, date_modified=None, release_date=None, is_editable=False, is_dataset=False, dataset_description=None
     ):
-        super(Links, self).__init__(request_id, privacy, date_modified, is_editable, is_dataset, dataset_description)
+        super(Links, self).__init__(request_id, privacy, date_modified, release_date, is_editable, is_dataset, dataset_description)
         self.title = title
         self.url = url
 
@@ -1699,10 +1700,10 @@ class Instructions(Responses):
     content = db.Column(db.String)
 
     def __init__(
-        self, request_id, privacy, content, date_modified=None, is_editable=False
+        self, request_id, privacy, content, date_modified=None, release_date=None, is_editable=False
     ):
         super(Instructions, self).__init__(
-            request_id, privacy, date_modified, is_editable
+            request_id, privacy, date_modified, release_date, is_editable
         )
         self.content = content
 
@@ -1742,9 +1743,10 @@ class Emails(Responses):
         subject,
         body,
         date_modified=None,
+        release_date=None,
         is_editable=False,
     ):
-        super(Emails, self).__init__(request_id, privacy, date_modified, is_editable)
+        super(Emails, self).__init__(request_id, privacy, date_modified, release_date, is_editable)
         self.to = to
         self.cc = cc
         self.bcc = bcc
@@ -1774,9 +1776,9 @@ class Envelopes(Responses):
     latex = db.Column(db.String)
 
     def __init__(
-        self, request_id, privacy, latex, date_modified=None, is_editable=False
+        self, request_id, privacy, latex, date_modified=None, release_date=None, is_editable=False
     ):
-        super(Envelopes, self).__init__(request_id, privacy, date_modified, is_editable)
+        super(Envelopes, self).__init__(request_id, privacy, date_modified, release_date, is_editable)
         self.latex = latex
 
     @property
@@ -1841,9 +1843,9 @@ class Letters(Responses):
     content = db.Column(db.String)
 
     def __init__(
-        self, request_id, privacy, title, content, date_modified=None, is_editable=False
+        self, request_id, privacy, title, content, date_modified=None, release_date=None, is_editable=False
     ):
-        super(Letters, self).__init__(request_id, privacy, date_modified, is_editable)
+        super(Letters, self).__init__(request_id, privacy, date_modified, release_date, is_editable)
         self.title = title
         self.content = content
 

--- a/app/request/views.py
+++ b/app/request/views.py
@@ -286,7 +286,7 @@ def view(request_id):
     """
     try:
         current_request = Requests.query.filter_by(id=request_id).one()
-        assert current_request.agency.is_active
+        assert current_request.agency.is_active or current_request.status is request_status.CLOSED
     except NoResultFound:
         print("Request with id '{}' does not exist.".format(request_id))
         sentry.captureException()

--- a/app/templates/request/responses/modal_body/determinations.html
+++ b/app/templates/request/responses/modal_body/determinations.html
@@ -2,14 +2,14 @@
     <p>Expected date of completion: <strong>{{ moment(response.date).format('dddd, MM/DD/YYYY [at] h:mm A')}}</strong></p>
     {% if response.reason is not none %}
         <div class="request-description-text">
-            {{ response.content | safe }}
+            {{ response.reason | safe }}
         </div>
     {% endif %}
 {% elif response.dtype == determination_type.EXTENSION %}
     <p>Due date changed to: <strong>{{ moment(response.date).format('dddd, MM/DD/YYYY [at] h:mm A') }}</strong></p>
     {% if response.reason is not none %}
         <div class="request-description-text">
-            {{ response.content | safe }}
+            {{ response.reason | safe }}
         </div>
     {% endif %}
 {% elif response.dtype in (determination_type.DENIAL, determination_type.CLOSING) %}


### PR DESCRIPTION
This PR fixes an issue with creating responses due to adding `release_date` to the `Responses` constructor. `release_date` was added so that we can manually set a release date for determinations (used in `add_closing_cli`) rather than the default 20 business days. Constructors and super functions updated for Files, Links, Instructions, Notes, Emails, Letters, Envelopes.

Other changes:
- Fixed an issue with acknowledgement/extension reason not showing because of wrong variable name.
- Fixed an issue with closed requests from an inactive agency not showing on view request page.